### PR TITLE
Add public class to use for holding SQL fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- New class `SqlFragment` can be used when passing raw SQL to the quoter. The
+  quoter already supports objects (on which it will call `__toString()`), this
+  class simply helps with the implementation.
 
 ## [1.0.0] - 2017-04-10
 ### Changed

--- a/src/SqlFragment.php
+++ b/src/SqlFragment.php
@@ -1,16 +1,20 @@
 <?php
 
-namespace Phlib\Db\Tests;
+namespace Phlib\Db;
 
-class ToStringClass
+/**
+ * This class will hold a SQL fragment and return it when cast to a string by Db::quote()
+ * to avoid the string otherwise being quoted as a value
+ */
+class SqlFragment
 {
     /**
      * @var string
      */
-    private $value = '';
+    private $value;
 
     /**
-     * @param string $value
+     * @param string $value SQL expression
      */
     public function __construct($value)
     {

--- a/tests/Adapter/QuoteHandlerTest.php
+++ b/tests/Adapter/QuoteHandlerTest.php
@@ -3,7 +3,7 @@
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\QuoteHandler;
-use Phlib\Db\Tests\ToStringClass;
+use Phlib\Db\SqlFragment;
 
 class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,7 +33,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
     public function valueDataProvider()
     {
         $toStringVal = 'foo';
-        $object = new ToStringClass($toStringVal);
+        $object = new SqlFragment($toStringVal);
         return [
             [false, 0],
             [true, 1],
@@ -74,7 +74,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
             ['field IN (1, 2, 3)', 'field IN (?)', [1, 2, 3]],
             ["field IN (`one`, `two`)", 'field IN (?)', ['one', 'two']],
             ["field IN (`one`, `Array`)", 'field IN (?)', ['one', ['two']]],
-            ['field = NOW()', 'field = ?', new ToStringClass('NOW()')]
+            ['field = NOW()', 'field = ?', new SqlFragment('NOW()')]
         ];
     }
 
@@ -148,8 +148,8 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
         return [
             ["`col1`", 'col1', null],
             ["`col1`", 'col1', true],
-            ["NOW()", new ToStringClass('NOW()'), true],
-            ["`col1`.NOW()", ['col1', new ToStringClass('NOW()')], true],
+            ["NOW()", new SqlFragment('NOW()'), true],
+            ["`col1`.NOW()", ['col1', new SqlFragment('NOW()')], true],
             ["`table1`.`*`", 'table1.*', true]
         ];
     }

--- a/tests/SqlFragmentTest.php
+++ b/tests/SqlFragmentTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Phlib\Db\Tests;
+
+use Phlib\Db\SqlFragment;
+use PHPUnit\Framework\TestCase;
+
+class SqlFragmentTest extends TestCase
+{
+    public function testToString()
+    {
+        $value = 'abc123';
+        $sqlFragment = new SqlFragment($value);
+        self::assertEquals($value, (string)$sqlFragment);
+    }
+}


### PR DESCRIPTION
This can be used when passing raw SQL to the quoter.

Will make it easier for implementations using the quoter if they don't have to create their own class for such a simple op.