### PR TITLE
Automatically quote identifiers in insert/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - New method on adapter `upsert()` for performing an insert/on duplicate update
   of a single row
+### Fixed
+- **BC break**: Automatically quote identifiers used in data parameters for
+  `insert()` and `update()`. Implementations must remove any manual identifer 
+  quotes that they were previously forced to include manually.
 
 ## [1.1.0] - 2017-11-15
 ### Added

--- a/src/Adapter/CrudTrait.php
+++ b/src/Adapter/CrudTrait.php
@@ -34,7 +34,7 @@ trait CrudTrait
     public function insert($table, array $data)
     {
         $table  = $this->quote()->identifier($table);
-        $fields = implode(', ', array_keys($data));
+        $fields = implode(', ', array_map([$this->quote(), 'identifier'], array_keys($data)));
         $values = implode(', ', array_map([$this->quote(), 'value'], $data));
         $sql = "INSERT INTO $table ($fields) VALUES ($values)";
 
@@ -57,7 +57,8 @@ trait CrudTrait
         $table  = $this->quote()->identifier($table);
         $fields = [];
         foreach ($data as $field => $value) {
-            $fields[] = $this->quote()->into("{$field} = ?", $value);
+            $identifier = $this->quote()->identifier($field);
+            $fields[] = $this->quote()->into("{$identifier} = ?", $value);
         }
         $sql = "UPDATE $table SET " . implode(', ', $fields);
         if (is_array($where)) {

--- a/tests/Adapter/CrudTraitTest.php
+++ b/tests/Adapter/CrudTraitTest.php
@@ -115,12 +115,12 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     public function insertDataProvider()
     {
         return [
-            ["INSERT INTO `table` (col1) VALUES ('v1')", 'table', ['col1' => 'v1']],
-            ["INSERT INTO `table` (col1, col2) VALUES ('v1', 'v2')", 'table', ['col1' => 'v1', 'col2' => 'v2']],
+            ["INSERT INTO `table` (`col1`) VALUES ('v1')", 'table', ['col1' => 'v1']],
+            ["INSERT INTO `table` (`col1`, `col2`) VALUES ('v1', 'v2')", 'table', ['col1' => 'v1', 'col2' => 'v2']],
             // Number should not be quoted
-            ["INSERT INTO `table` (col1) VALUES (123)", 'table', ['col1' => 123]],
+            ["INSERT INTO `table` (`col1`) VALUES (123)", 'table', ['col1' => 123]],
             // Object should be handled
-            ["INSERT INTO `table` (col1) VALUES (col2)", 'table', ['col1' => new SqlFragment('col2')]],
+            ["INSERT INTO `table` (`col1`) VALUES (col2)", 'table', ['col1' => new SqlFragment('col2')]],
         ];
     }
 
@@ -157,11 +157,11 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     public function updateDataProvider()
     {
         return [
-            ["UPDATE `table` SET col1 = 'v1'", 'table', ['col1' => 'v1'], [], []],
-            ["UPDATE `table` SET col1 = 'v1', col2 = 'v2'", 'table', ['col1' => 'v1', 'col2' => 'v2'], [], []],
+            ["UPDATE `table` SET `col1` = 'v1'", 'table', ['col1' => 'v1'], [], []],
+            ["UPDATE `table` SET `col1` = 'v1', `col2` = 'v2'", 'table', ['col1' => 'v1', 'col2' => 'v2'], [], []],
             // Deprecated $where param as string
             [
-                "UPDATE `table` SET col1 = 'v1', col2 = 'v2' WHERE col3 = 'v3'",
+                "UPDATE `table` SET `col1` = 'v1', `col2` = 'v2' WHERE col3 = 'v3'",
                 'table',
                 ['col1' => 'v1', 'col2' => 'v2'],
                 "col3 = 'v3'",
@@ -169,14 +169,14 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
             ],
             // Deprecated $where param as string with bind
             [
-                "UPDATE `table` SET col1 = 'v1' WHERE col3 = 'v3' AND col4 = ?",
+                "UPDATE `table` SET `col1` = 'v1' WHERE col3 = 'v3' AND col4 = ?",
                 'table',
                 ['col1' => 'v1'],
                 "col3 = 'v3' AND col4 = ?",
                 ['v4']
             ],
             [
-                "UPDATE `table` SET col1 = 'v1' WHERE col3 = 'v3' AND col4 = 'v4' AND col5 IS NULL",
+                "UPDATE `table` SET `col1` = 'v1' WHERE col3 = 'v3' AND col4 = 'v4' AND col5 IS NULL",
                 'table',
                 ['col1' => 'v1'],
                 ['col3 = ?' => 'v3', 'col4 = ?' => 'v4', 'col5 IS NULL'],
@@ -184,7 +184,7 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
             ],
             // Correct quote behaviour for number and object
             [
-                "UPDATE `table` SET col1 = 'v1' WHERE col3 = 123 AND col4 = col2",
+                "UPDATE `table` SET `col1` = 'v1' WHERE col3 = 123 AND col4 = col2",
                 'table',
                 ['col1' => 'v1'],
                 ['col3 = ?' => 123, 'col4 = ?' => new SqlFragment('col2')],


### PR DESCRIPTION
BC break for those identifiers which require implementations to have already manually quoted.