### PR TITLE
Integration test

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,6 +20,19 @@ jobs:
 
     name: PHP ${{ matrix.php }} tests
 
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_DATABASE: test_database
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_USER: admin
+          MYSQL_PASSWORD: rootpass
+          MYSQL_ROOT_PASSWORD: rootpass
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,6 +57,13 @@ jobs:
 
       - name: PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        env:
+          INTEGRATION_ENABLED: 1
+          INTEGRATION_HOST: 127.0.0.1
+          INTEGRATION_PORT: 3306
+          INTEGRATION_USERNAME: root
+          INTEGRATION_PASSWORD: rootpass
+          INTEGRATION_DATABASE: test_database
 
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: Automatically quote identifiers used in data parameters for
   `insert()` and `update()`. Implementations must remove any manual identifer 
   quotes that they were previously forced to include manually.
+- `RuntimeException::createFromException()` no longer wraps an instance of itself.
 ### Removed
 - Previous deprecated *bind* parameter for `select()`, `update()` and
   `delete()`, and passing a string to the *where* parameter.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="vendor/autoload.php" colors="true">
+    <php>
+        <env name="INTEGRATION_ENABLED" value="0" />
+        <env name="INTEGRATION_HOST" value="127.0.0.1" />
+        <env name="INTEGRATION_PORT" value="3306" />
+        <env name="INTEGRATION_USERNAME" value="" />
+        <env name="INTEGRATION_PASSWORD" value="" />
+        <env name="INTEGRATION_DATABASE" value="mysql" />
+    </php>
     <testsuites>
         <testsuite name="DB Test Suite">
             <directory>tests</directory>

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -10,6 +10,10 @@ class RuntimeException extends \PDOException implements Exception
      */
     public static function createFromException(\PDOException $exception)
     {
+        if ($exception instanceof static) {
+            return $exception;
+        }
+
         $newSelf = new static($exception->getMessage(), 0, $exception);
         $newSelf->code = $exception->getCode();
         return $newSelf;

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Phlib\Db\Tests;
+
+use Phlib\Db\Adapter;
+use Phlib\Db\Exception\InvalidQueryException;
+use Phlib\Db\Exception\RuntimeException;
+use Phlib\Db\Exception\UnknownDatabaseException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group integration
+ */
+class IntegrationTest extends TestCase
+{
+    /**
+     * @var Adapter
+     */
+    private $adapter;
+
+    protected function setUp()
+    {
+        if ((bool)getenv('INTEGRATION_ENABLED') !== true) {
+            static::markTestSkipped();
+            return;
+        }
+
+        parent::setUp();
+
+        $this->adapter = new Adapter([
+            'host' => getenv('INTEGRATION_HOST'),
+            'port' => getenv('INTEGRATION_PORT'),
+            'username' => getenv('INTEGRATION_USERNAME'),
+            'password' => getenv('INTEGRATION_PASSWORD'),
+        ]);
+    }
+
+    public function testPing()
+    {
+        static::assertTrue($this->adapter->ping());
+    }
+
+    public function testQuery()
+    {
+        $expected = rand();
+
+        $stmt = $this->adapter->query('SELECT ' . $expected);
+        $result = $stmt->fetchColumn();
+
+        static::assertSame((string)$expected, $result);
+    }
+
+    public function testRuntimeException()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Access denied');
+        $this->expectExceptionCode(1045);
+
+        $adapter = new Adapter([
+            'host' => getenv('INTEGRATION_HOST'),
+            'port' => getenv('INTEGRATION_PORT'),
+            'username' => 'invalid_user',
+            'password' => 'invalid_pass',
+        ]);
+
+        $adapter->getConnection();
+    }
+
+    public function testInvalidQueryException()
+    {
+        $this->expectException(InvalidQueryException::class);
+        $this->expectExceptionMessage('error in your SQL syntax');
+        $this->expectExceptionCode(42000);
+
+        $this->adapter->query('SELECT foo FROM bar WHERE');
+    }
+
+    public function testSetDatabaseNotConnectedSuccess()
+    {
+        // Connection not active, will just update config
+        $this->adapter->setDatabase(getenv('INTEGRATION_DATABASE'));
+
+        // Connection made, no exception for set database
+        static::assertTrue($this->adapter->ping());
+    }
+
+    public function testSetDatabaseAlreadyConnectedSuccess()
+    {
+        // Make sure connected
+        static::assertTrue($this->adapter->ping());
+
+        // No exception should be thrown for valid database
+        $this->adapter->setDatabase(getenv('INTEGRATION_DATABASE'));
+
+        // Still connected
+        static::assertTrue($this->adapter->ping());
+    }
+
+    /**
+     * This test needs the user to have global privileges, otherwise the error will be 'access denied'
+     */
+    public function testSetDatabaseNotConnectedFail()
+    {
+        // Connection not active, will just update config, no exception
+        $this->adapter->setDatabase('database_does_not_exist');
+
+        // Trigger connection, exception should be thrown
+        $this->expectException(UnknownDatabaseException::class);
+        $this->expectExceptionCode(UnknownDatabaseException::ER_BAD_DB_ERROR_1);
+        $this->adapter->query('SELECT 1');
+    }
+
+    /**
+     * This test needs the user to have global privileges, otherwise the error will be 'access denied'
+     */
+    public function testSetDatabaseAlreadyConnectedFail()
+    {
+        // Make sure connected
+        static::assertTrue($this->adapter->ping());
+
+        $this->expectException(UnknownDatabaseException::class);
+        $this->expectExceptionCode(UnknownDatabaseException::ER_BAD_DB_ERROR_1);
+        $this->adapter->setDatabase('database_does_not_exist');
+    }
+}


### PR DESCRIPTION
Add very basic integration tests, to make sure that connections and exceptions work.

Update `RuntimeException::createFromException()` so it no longer creates a new `RuntimeException` when the given exception is already an instance of `RuntimeException`.