### PR TITLE
Add support for PHP v8

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         php:
           - '7.4'
+          - '8.0'
 
     name: PHP ${{ matrix.php }} tests
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,18 +11,13 @@ jobs:
     strategy:
       matrix:
         php:
-          - '5.6'
-          - '7.0'
-          - '7.1'
-          - '7.2'
-          - '7.3'
           - '7.4'
 
     name: PHP ${{ matrix.php }} tests
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:latest
         env:
           MYSQL_DATABASE: test_database
           MYSQL_HOST: 127.0.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-vendor/
-composer.lock
-phpunit.xml
+/vendor
+/composer.lock
+/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Add specific support for PHP v8.
 - Type declarations have been added to all method parameters and return types
   where possible. Some methods return mixed type so docblocks are still used.
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   quotes that they were previously forced to include manually.
 - `RuntimeException::createFromException()` no longer wraps an instance of itself.
 ### Removed
+- **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
+  [actively supported](https://php.net/supported-versions.php) by the PHP project.
 - Previous deprecated *bind* parameter for `select()`, `update()` and
   `delete()`, and passing a string to the *where* parameter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `insert()` and `update()`. Implementations must remove any manual identifier 
   quotes that they were previously forced to include manually.
 - `RuntimeException::createFromException()` no longer wraps an instance of itself.
+### Changed
+- **BC break**: `QuoteHandler` construct requires a `Closure` rather than simply
+  allowing any callable. The signature is definied to accept a mixed parameter
+  and return a string.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.
+- **BC break**: Removed *type* parameter from `QuoteHandler::value()` (and
+  therefore also `QuoteHandler::into()`). This method is designed to
+  automatically handle the type, and remove the need to instruct it.
 - Previous deprecated *bind* parameter for `select()`, `update()` and
   `delete()`, and passing a string to the *where* parameter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Type declarations have been added to all method parameters and return types
+  where possible. Some methods return mixed type so docblocks are still used.
 ### Fixed
 - **BC break**: Automatically quote identifiers used in data parameters for
   `insert()` and `update()`. Implementations must remove any manual identifier 
@@ -14,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: `QuoteHandler` construct requires a `Closure` rather than simply
   allowing any callable. The signature is definied to accept a mixed parameter
   and return a string.
+- **BC break**: `QuoteHandler::columnAs()` and `QuoteHandler::tableAs()` no 
+  longer accept `null` as a value for *alias*. This unexpected behaviour is
+  removed by adding type declarations.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v7.3 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-pdo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8",
+        "phpunit/phpunit": "^9",
         "symplify/easy-coding-standard": "^9"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-pdo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^8",
         "symplify/easy-coding-standard": "^9"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-pdo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.4",
         "ext-pdo": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "ext-pdo": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-pdo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6"
+        "phpunit/phpunit": "^7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "ext-pdo": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^7",
+        "symplify/easy-coding-standard": "^9"
     },
     "autoload": {
         "psr-4": {
@@ -32,5 +33,9 @@
        "psr-4": {
            "Phlib\\Db\\Tests\\": "tests/"
        }
+    },
+    "scripts": {
+        "cs-check": "vendor/bin/ecs",
+        "cs-fix": "vendor/bin/ecs --fix"
     }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $services = $containerConfigurator->services();
+
+    $containerConfigurator->import(SetList::COMMON);
+    // Remove sniff, from common/control-structures
+    $services->remove(\PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer::class);
+    // Remove sniff, from common/spaces
+    $services->remove(\PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer::class);
+    $services->remove(\PhpCsFixer\Fixer\CastNotation\CastSpacesFixer::class);
+
+    $containerConfigurator->import(SetList::PSR_12);
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<phpunit
+    bootstrap="vendor/autoload.php"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutChangesToGlobalState="true"
+    colors="true"
+>
     <php>
         <env name="INTEGRATION_ENABLED" value="0" />
         <env name="INTEGRATION_HOST" value="127.0.0.1" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     bootstrap="vendor/autoload.php"
-    beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutChangesToGlobalState="true"
     colors="true"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutChangesToGlobalState="true"
@@ -14,13 +16,13 @@
         <env name="INTEGRATION_DATABASE" value="test" />
     </php>
     <testsuites>
-        <testsuite name="DB Test Suite">
+        <testsuite name="Phlib Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -3,8 +3,8 @@
 namespace Phlib\Db;
 
 use Phlib\Db\Exception\InvalidQueryException;
-use Phlib\Db\Exception\UnknownDatabaseException;
 use Phlib\Db\Exception\RuntimeException;
+use Phlib\Db\Exception\UnknownDatabaseException;
 
 class Adapter implements AdapterInterface
 {
@@ -31,16 +31,13 @@ class Adapter implements AdapterInterface
     private $quoter;
 
     /**
-     * Constructor
-     *
-     * === Config Params ===
-     * host
-     * username
-     * password
-     * [port]
-     * [dbname]
-     *
-     * @param array $config
+     * @param array $config {
+     *   @var string $host required
+     *   @var string $username required
+     *   @var string $password required
+     *   @var int $port optional
+     *   @var string $dbname optional
+     * }
      */
     public function __construct(array $config = [])
     {
@@ -64,7 +61,6 @@ class Adapter implements AdapterInterface
 
     /**
      * Sets the item which creates a new DB connection.
-     * @param callable $factory
      * @return $this
      */
     public function setConnectionFactory(callable $factory)
@@ -120,7 +116,6 @@ class Adapter implements AdapterInterface
     /**
      * Set the database connection.
      *
-     * @param \PDO $connection
      * @return Adapter
      */
     public function setConnection(\PDO $connection)
@@ -293,7 +288,6 @@ class Adapter implements AdapterInterface
      * Execute an SQL statement
      *
      * @param string $statement
-     * @param array $bind
      * @return int
      */
     public function execute($statement, array $bind = [])
@@ -306,7 +300,6 @@ class Adapter implements AdapterInterface
      * Query the database.
      *
      * @param string $sql
-     * @param array $bind
      * @throws \PDOException
      * @return \PDOStatement
      */
@@ -317,7 +310,6 @@ class Adapter implements AdapterInterface
 
     /**
      * @param string $sql
-     * @param array $bind
      * @param bool $hasCaughtException
      * @return \PDOStatement
      */
@@ -345,7 +337,7 @@ class Adapter implements AdapterInterface
      */
     private function connect()
     {
-        if (is_null($this->connection)) {
+        if ($this->connection === null) {
             $this->connection = call_user_func($this->connectionFactory, $this->config);
         }
 

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -167,7 +167,7 @@ class Adapter implements AdapterInterface
     public function ping(): bool
     {
         try {
-            return ($this->query('SELECT 1')->fetchColumn() == 1);
+            return ($this->query('SELECT 1')->fetchColumn() === '1');
         } catch (\Exception $e) {
             return false;
         }

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -51,8 +51,8 @@ class Adapter implements AdapterInterface
     public function quote()
     {
         if (!isset($this->quoter)) {
-            $this->quoter = new Adapter\QuoteHandler(function ($value, $type) {
-                return $this->getConnection()->quote($value, $type);
+            $this->quoter = new Adapter\QuoteHandler(function ($value): string {
+                return $this->getConnection()->quote($value);
             });
         }
 

--- a/src/Adapter/Config.php
+++ b/src/Adapter/Config.php
@@ -48,7 +48,7 @@ class Config
      */
     public function getUsername()
     {
-        return isset($this->config['username']) ? $this->config['username'] : '';
+        return $this->config['username'] ?? '';
     }
 
     /**
@@ -56,7 +56,7 @@ class Config
      */
     public function getPassword()
     {
-        return isset($this->config['password']) ? $this->config['password'] : '';
+        return $this->config['password'] ?? '';
     }
 
     /**
@@ -64,7 +64,7 @@ class Config
      */
     public function getOptions()
     {
-        $timeoutValue   = isset($this->config['timeout']) ? $this->config['timeout'] : '';
+        $timeoutValue   = $this->config['timeout'] ?? '';
         $timeoutOptions = ['options' => ['min_range' => 0, 'max_range' => 120, 'default' => 2]];
         $timeout        = filter_var($timeoutValue, FILTER_VALIDATE_INT, $timeoutOptions);
         return [
@@ -79,7 +79,7 @@ class Config
      */
     public function getDatabase()
     {
-        return isset($this->config['dbname'])  ? $this->config['dbname']  : '';
+        return $this->config['dbname'] ?? '';
     }
 
     /**
@@ -97,7 +97,7 @@ class Config
      */
     public function getCharset()
     {
-        return isset($this->config['charset'])  ? $this->config['charset']  : 'utf8mb4';
+        return $this->config['charset'] ?? 'utf8mb4';
     }
 
     /**
@@ -115,7 +115,7 @@ class Config
      */
     public function getTimezone()
     {
-        return isset($this->config['timezone']) ? $this->config['timezone'] : '+0:00';
+        return $this->config['timezone'] ?? '+0:00';
     }
 
     /**
@@ -133,7 +133,7 @@ class Config
      */
     public function getMaximumAttempts()
     {
-        $retryValue   = isset($this->config['retryCount']) ? $this->config['retryCount'] : 0;
+        $retryValue   = $this->config['retryCount'] ?? 0;
         $retryOptions = ['options' => ['min_range' => 0, 'max_range' => 10, 'default' => 0]];
         $retryCount   = filter_var($retryValue, FILTER_VALIDATE_INT, $retryOptions);
         return $retryCount + 1;

--- a/src/Adapter/Config.php
+++ b/src/Adapter/Config.php
@@ -11,15 +11,11 @@ class Config
      */
     private $config;
 
-    /**
-     * Config constructor.
-     * @param array $config
-     */
     public function __construct(array $config)
     {
         $this->config = $config + [
-            'charset'  => 'utf8mb4',
-            'timezone' => '+0:00'
+            'charset' => 'utf8mb4',
+            'timezone' => '+0:00',
         ];
     }
 
@@ -64,13 +60,19 @@ class Config
      */
     public function getOptions()
     {
-        $timeoutValue   = $this->config['timeout'] ?? '';
-        $timeoutOptions = ['options' => ['min_range' => 0, 'max_range' => 120, 'default' => 2]];
-        $timeout        = filter_var($timeoutValue, FILTER_VALIDATE_INT, $timeoutOptions);
+        $timeoutValue = $this->config['timeout'] ?? '';
+        $timeoutOptions = [
+            'options' => [
+                'min_range' => 0,
+                'max_range' => 120,
+                'default' => 2,
+            ],
+        ];
+        $timeout = filter_var($timeoutValue, FILTER_VALIDATE_INT, $timeoutOptions);
         return [
-            \PDO::ATTR_TIMEOUT            => $timeout,
-            \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
-            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC
+            \PDO::ATTR_TIMEOUT => $timeout,
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
         ];
     }
 
@@ -133,9 +135,15 @@ class Config
      */
     public function getMaximumAttempts()
     {
-        $retryValue   = $this->config['retryCount'] ?? 0;
-        $retryOptions = ['options' => ['min_range' => 0, 'max_range' => 10, 'default' => 0]];
-        $retryCount   = filter_var($retryValue, FILTER_VALIDATE_INT, $retryOptions);
+        $retryValue = $this->config['retryCount'] ?? 0;
+        $retryOptions = [
+            'options' => [
+                'min_range' => 0,
+                'max_range' => 10,
+                'default' => 0,
+            ],
+        ];
+        $retryCount = filter_var($retryValue, FILTER_VALIDATE_INT, $retryOptions);
         return $retryCount + 1;
     }
 

--- a/src/Adapter/Config.php
+++ b/src/Adapter/Config.php
@@ -1,15 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Adapter;
 
 use Phlib\Db\Exception\InvalidArgumentException;
 
 class Config
 {
-    /**
-     * @var array
-     */
-    private $config;
+    private array $config;
 
     public function __construct(array $config)
     {
@@ -19,11 +18,7 @@ class Config
         ];
     }
 
-    /**
-     * @return string
-     * @throws InvalidArgumentException
-     */
-    public function getDsn()
+    public function getDsn(): string
     {
         if (!isset($this->config['host'])) {
             throw new InvalidArgumentException('Missing host config param');
@@ -39,26 +34,17 @@ class Config
         return $dsn;
     }
 
-    /**
-     * @return string
-     */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->config['username'] ?? '';
     }
 
-    /**
-     * @return string
-     */
-    public function getPassword()
+    public function getPassword(): string
     {
         return $this->config['password'] ?? '';
     }
 
-    /**
-     * @return array
-     */
-    public function getOptions()
+    public function getOptions(): array
     {
         $timeoutValue = $this->config['timeout'] ?? '';
         $timeoutOptions = [
@@ -76,64 +62,40 @@ class Config
         ];
     }
 
-    /**
-     * @return string
-     */
-    public function getDatabase()
+    public function getDatabase(): string
     {
         return $this->config['dbname'] ?? '';
     }
 
-    /**
-     * @param string $name
-     * @return $this
-     */
-    public function setDatabase($name)
+    public function setDatabase(string $name): self
     {
         $this->config['dbname'] = $name;
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getCharset()
+    public function getCharset(): string
     {
         return $this->config['charset'] ?? 'utf8mb4';
     }
 
-    /**
-     * @param string $value
-     * @return $this
-     */
-    public function setCharset($value)
+    public function setCharset(string $value): self
     {
         $this->config['charset'] = $value;
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTimezone()
+    public function getTimezone(): string
     {
         return $this->config['timezone'] ?? '+0:00';
     }
 
-    /**
-     * @param string $timezone
-     * @return $this
-     */
-    public function setTimezone($timezone)
+    public function setTimezone(string $timezone): self
     {
         $this->config['timezone'] = $timezone;
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getMaximumAttempts()
+    public function getMaximumAttempts(): int
     {
         $retryValue = $this->config['retryCount'] ?? 0;
         $retryOptions = [
@@ -147,10 +109,7 @@ class Config
         return $retryCount + 1;
     }
 
-    /**
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->config;
     }

--- a/src/Adapter/ConnectionFactory.php
+++ b/src/Adapter/ConnectionFactory.php
@@ -31,7 +31,7 @@ class ConnectionFactory
 
                 if ($maxAttempts > $attempt) {
                     // sleep with some exponential backoff
-                    $msec = pow(2, $attempt) * 50;
+                    $msec = (2 ** $attempt) * 50;
                     usleep($msec * 1000);
                 } else {
                     // ran out of attempts, throw the last error

--- a/src/Adapter/ConnectionFactory.php
+++ b/src/Adapter/ConnectionFactory.php
@@ -8,14 +8,13 @@ use Phlib\Db\Exception\UnknownDatabaseException;
 class ConnectionFactory
 {
     /**
-     * @param Config $config
      * @return \PDO
      * @throws UnknownDatabaseException
      * @throws RuntimeException
      */
     public function __invoke(Config $config)
     {
-        $attempt     = 0;
+        $attempt = 0;
         $maxAttempts = $config->getMaximumAttempts();
         while (++$attempt <= $maxAttempts) {
             try {
@@ -42,7 +41,6 @@ class ConnectionFactory
     }
 
     /**
-     * @param Config $config
      * @return \PDO
      */
     public function create(Config $config)

--- a/src/Adapter/ConnectionFactory.php
+++ b/src/Adapter/ConnectionFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Adapter;
 
 use Phlib\Db\Exception\RuntimeException;
@@ -7,12 +9,7 @@ use Phlib\Db\Exception\UnknownDatabaseException;
 
 class ConnectionFactory
 {
-    /**
-     * @return \PDO
-     * @throws UnknownDatabaseException
-     * @throws RuntimeException
-     */
-    public function __invoke(Config $config)
+    public function __invoke(Config $config): \PDO
     {
         $attempt = 0;
         $maxAttempts = $config->getMaximumAttempts();
@@ -40,10 +37,7 @@ class ConnectionFactory
         }
     }
 
-    /**
-     * @return \PDO
-     */
-    public function create(Config $config)
+    public function create(Config $config): \PDO
     {
         return new \PDO(
             $config->getDsn(),

--- a/src/Adapter/CrudTrait.php
+++ b/src/Adapter/CrudTrait.php
@@ -8,13 +8,12 @@ trait CrudTrait
      * Select data from table.
      *
      * @param string $table
-     * @param array $where
      * @return \PDOStatement
      */
     public function select($table, array $where = [])
     {
         $table = $this->quote()->identifier($table);
-        $sql   = "SELECT * FROM $table";
+        $sql = "SELECT * FROM {$table}";
 
         $where = $this->createWhereExpression($where);
         if (!empty($where)) {
@@ -28,15 +27,14 @@ trait CrudTrait
      * Insert data to table.
      *
      * @param string $table
-     * @param array $data
      * @return int Number of affected rows
      */
     public function insert($table, array $data)
     {
-        $table  = $this->quote()->identifier($table);
+        $table = $this->quote()->identifier($table);
         $fields = implode(', ', array_map([$this->quote(), 'identifier'], array_keys($data)));
         $values = implode(', ', array_map([$this->quote(), 'value'], $data));
-        $sql = "INSERT INTO $table ($fields) VALUES ($values)";
+        $sql = "INSERT INTO {$table} ({$fields}) VALUES ({$values})";
 
         $stmt = $this->query($sql);
 
@@ -47,19 +45,17 @@ trait CrudTrait
      * Update data in table.
      *
      * @param string $table
-     * @param array $data
-     * @param array $where
      * @return int Number of affected rows
      */
     public function update($table, array $data, array $where = [])
     {
-        $table  = $this->quote()->identifier($table);
+        $table = $this->quote()->identifier($table);
         $fields = [];
         foreach ($data as $field => $value) {
             $identifier = $this->quote()->identifier($field);
             $fields[] = $this->quote()->into("{$identifier} = ?", $value);
         }
-        $sql = "UPDATE $table SET " . implode(', ', $fields);
+        $sql = "UPDATE {$table} SET " . implode(', ', $fields);
 
         $where = $this->createWhereExpression($where);
         if (!empty($where)) {
@@ -75,13 +71,12 @@ trait CrudTrait
      * Delete from table.
      *
      * @param string $table
-     * @param array $where
      * @return int Number of affected rows
      */
     public function delete($table, array $where = [])
     {
         $table = $this->quote()->identifier($table);
-        $sql   = "DELETE FROM $table";
+        $sql = "DELETE FROM {$table}";
 
         $where = $this->createWhereExpression($where);
         if (!empty($where)) {
@@ -97,22 +92,20 @@ trait CrudTrait
      * Insert (on duplicate key update) data in table.
      *
      * @param string $table
-     * @param array $data
-     * @param array $updateFields
      * @return int Number of affected rows
      */
     public function upsert($table, array $data, array $updateFields)
     {
-        $table  = $this->quote()->identifier($table);
+        $table = $this->quote()->identifier($table);
         $fields = implode(', ', array_map([$this->quote(), 'identifier'], array_keys($data)));
         $placeHolders = implode(', ', array_fill(0, count($data), '?'));
         $updateValues = [];
         foreach ($updateFields as $field) {
             $field = $this->quote()->identifier($field);
-            $updateValues[] = "$field = VALUES($field)";
+            $updateValues[] = "{$field} = VALUES({$field})";
         }
         $updates = implode(', ', $updateValues);
-        $sql = "INSERT INTO $table ($fields) VALUES ($placeHolders) ON DUPLICATE KEY UPDATE $updates";
+        $sql = "INSERT INTO {$table} ({$fields}) VALUES ({$placeHolders}) ON DUPLICATE KEY UPDATE {$updates}";
 
         $stmt = $this->query($sql, array_values($data));
 
@@ -122,7 +115,6 @@ trait CrudTrait
     /**
      * Create WHERE expression from given criteria
      *
-     * @param array $where
      * @return string
      */
     private function createWhereExpression(array $where = [])
@@ -145,7 +137,6 @@ trait CrudTrait
 
     /**
      * @param string $sql
-     * @param array $bind
      * @throws \PDOException
      * @return \PDOStatement
      */

--- a/src/Adapter/CrudTrait.php
+++ b/src/Adapter/CrudTrait.php
@@ -1,16 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Adapter;
 
 trait CrudTrait
 {
-    /**
-     * Select data from table.
-     *
-     * @param string $table
-     * @return \PDOStatement
-     */
-    public function select($table, array $where = [])
+    public function select(string $table, array $where = []): \PDOStatement
     {
         $table = $this->quote()->identifier($table);
         $sql = "SELECT * FROM {$table}";
@@ -23,13 +19,7 @@ trait CrudTrait
         return $this->query($sql);
     }
 
-    /**
-     * Insert data to table.
-     *
-     * @param string $table
-     * @return int Number of affected rows
-     */
-    public function insert($table, array $data)
+    public function insert(string $table, array $data): int
     {
         $table = $this->quote()->identifier($table);
         $fields = implode(', ', array_map([$this->quote(), 'identifier'], array_keys($data)));
@@ -42,12 +32,9 @@ trait CrudTrait
     }
 
     /**
-     * Update data in table.
-     *
-     * @param string $table
      * @return int Number of affected rows
      */
-    public function update($table, array $data, array $where = [])
+    public function update(string $table, array $data, array $where = []): int
     {
         $table = $this->quote()->identifier($table);
         $fields = [];
@@ -68,12 +55,9 @@ trait CrudTrait
     }
 
     /**
-     * Delete from table.
-     *
-     * @param string $table
      * @return int Number of affected rows
      */
-    public function delete($table, array $where = [])
+    public function delete(string $table, array $where = []): int
     {
         $table = $this->quote()->identifier($table);
         $sql = "DELETE FROM {$table}";
@@ -89,12 +73,9 @@ trait CrudTrait
     }
 
     /**
-     * Insert (on duplicate key update) data in table.
-     *
-     * @param string $table
      * @return int Number of affected rows
      */
-    public function upsert($table, array $data, array $updateFields)
+    public function upsert(string $table, array $data, array $updateFields): int
     {
         $table = $this->quote()->identifier($table);
         $fields = implode(', ', array_map([$this->quote(), 'identifier'], array_keys($data)));
@@ -112,12 +93,7 @@ trait CrudTrait
         return $stmt->rowCount();
     }
 
-    /**
-     * Create WHERE expression from given criteria
-     *
-     * @return string
-     */
-    private function createWhereExpression(array $where = [])
+    private function createWhereExpression(array $where = []): string
     {
         $criteria = [];
         foreach ($where as $index => $value) {
@@ -130,15 +106,7 @@ trait CrudTrait
         return implode(' AND ', $criteria);
     }
 
-    /**
-     * @return QuoteHandler
-     */
-    abstract public function quote();
+    abstract public function quote(): QuoteHandler;
 
-    /**
-     * @param string $sql
-     * @throws \PDOException
-     * @return \PDOStatement
-     */
-    abstract public function query($sql, array $bind = []);
+    abstract public function query(string $sql, array $bind = []): \PDOStatement;
 }

--- a/src/Adapter/QuoteHandler.php
+++ b/src/Adapter/QuoteHandler.php
@@ -43,17 +43,13 @@ class QuoteHandler
                 if (!method_exists($value, '__toString')) {
                     throw new InvalidArgumentException('Object can not be converted to string value.');
                 }
-                $value = (string)$value;
-                break;
+                return (string)$value;
             case is_bool($value):
-                $value = (int)$value;
-                break;
+                return (int)$value;
             case (is_numeric($value) && (string)($value + 0) === (string)$value):
-                $value = $value + 0;
-                break;
+                return $value + 0;
             case $value === null:
-                $value = 'NULL';
-                break;
+                return 'NULL';
             case is_array($value):
                 $value = array_map(function ($value) {
                     if (is_array($value)) {
@@ -61,13 +57,10 @@ class QuoteHandler
                     }
                     return $this->value($value);
                 }, $value);
-                $value = implode(', ', $value);
-                break;
+                return implode(', ', $value);
             default:
-                $value = ($this->quoteFn)($value);
+                return ($this->quoteFn)($value);
         }
-
-        return $value;
     }
 
     /**

--- a/src/Adapter/QuoteHandler.php
+++ b/src/Adapter/QuoteHandler.php
@@ -1,29 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Adapter;
 
 use Phlib\Db\Exception\InvalidArgumentException;
 
 class QuoteHandler
 {
-    /**
-     * @var boolean
-     */
-    private $autoQuoteIdentifiers = true;
+    private bool $autoQuoteIdentifiers;
 
-    /**
-     * @var \Closure
-     */
-    private $quoteFn;
+    private \Closure $quoteFn;
 
     /**
      * @param \Closure $quoteFn {
      *   @var mixed $value
      *   @return string
      * }
-     * @param bool $autoQuoteIdentifiers
      */
-    public function __construct(\Closure $quoteFn, $autoQuoteIdentifiers = true)
+    public function __construct(\Closure $quoteFn, bool $autoQuoteIdentifiers = true)
     {
         $this->quoteFn = $quoteFn;
         $this->autoQuoteIdentifiers = $autoQuoteIdentifiers;
@@ -32,11 +27,9 @@ class QuoteHandler
     /**
      * Quote a database value.
      *
-     * @param string $value
-     * @return string
-     * @throws InvalidArgumentException
+     * @param mixed $value
      */
-    public function value($value)
+    public function value($value): string
     {
         switch (true) {
             case is_object($value):
@@ -45,9 +38,9 @@ class QuoteHandler
                 }
                 return (string)$value;
             case is_bool($value):
-                return (int)$value;
+                return (string)(int)$value;
             case (is_numeric($value) && (string)($value + 0) === (string)$value):
-                return $value + 0;
+                return (string)($value + 0);
             case $value === null:
                 return 'NULL';
             case is_array($value):
@@ -66,11 +59,9 @@ class QuoteHandler
     /**
      * Quote into the value for the database.
      *
-     * @param string $text
      * @param mixed $value
-     * @return string
      */
-    public function into($text, $value)
+    public function into(string $text, $value): string
     {
         return str_replace('?', $this->value($value), $text);
     }
@@ -78,12 +69,9 @@ class QuoteHandler
     /**
      * Quote a column identifier and alias.
      *
-     * @param string|array $ident
-     * @param string $alias
-     * @param boolean $auto
-     * @return string
+     * @param string|string[] $ident
      */
-    public function columnAs($ident, $alias, $auto = false)
+    public function columnAs($ident, string $alias, bool $auto = false): string
     {
         return $this->quoteIdentifierAs($ident, $alias, $auto);
     }
@@ -91,12 +79,9 @@ class QuoteHandler
     /**
      * Quote a table identifier and alias.
      *
-     * @param string|array $ident
-     * @param string $alias
-     * @param boolean $auto
-     * @return string
+     * @param string|string[] $ident
      */
-    public function tableAs($ident, $alias = null, $auto = false)
+    public function tableAs($ident, string $alias, bool $auto = false): string
     {
         return $this->quoteIdentifierAs($ident, $alias, $auto);
     }
@@ -104,11 +89,9 @@ class QuoteHandler
     /**
      * Quotes an identifier
      *
-     * @param string|array $ident
-     * @param boolean $auto
-     * @return string
+     * @param string|string[] $ident
      */
-    public function identifier($ident, $auto = false)
+    public function identifier($ident, bool $auto = false): string
     {
         return $this->quoteIdentifierAs($ident, null, $auto);
     }
@@ -117,13 +100,8 @@ class QuoteHandler
      * Quote an identifier and an optional alias.
      *
      * @param string|array|object $ident
-     * @param string $alias
-     * @param boolean $auto
-     * @param string $as
-     * @return string
-     * @throws InvalidArgumentException
      */
-    private function quoteIdentifierAs($ident, $alias = null, $auto = false, $as = ' AS ')
+    private function quoteIdentifierAs($ident, string $alias = null, bool $auto = false, string $as = ' AS '): string
     {
         if (is_object($ident) && method_exists($ident, 'assemble')) {
             $quoted = '(' . $ident->assemble() . ')';
@@ -161,14 +139,7 @@ class QuoteHandler
         return $quoted;
     }
 
-    /**
-     * Quote an identifier.
-     *
-     * @param string $value
-     * @param boolean $auto
-     * @return string
-     */
-    private function performQuoteIdentifier($value, $auto = false)
+    private function performQuoteIdentifier(string $value, bool $auto = false): string
     {
         if ($auto === false || $this->autoQuoteIdentifiers === true) {
             $q = '`';

--- a/src/Adapter/QuoteHandler.php
+++ b/src/Adapter/QuoteHandler.php
@@ -123,7 +123,7 @@ class QuoteHandler
                         $segments[] = $this->performQuoteIdentifier($segment, $auto);
                     }
                 }
-                if ($alias !== null && end($ident) == $alias) {
+                if ($alias !== null && end($ident) === $alias) {
                     $alias = null;
                 }
                 $quoted = implode('.', $segments);

--- a/src/Adapter/QuoteHandler.php
+++ b/src/Adapter/QuoteHandler.php
@@ -6,7 +6,6 @@ use Phlib\Db\Exception\InvalidArgumentException;
 
 class QuoteHandler
 {
-
     /**
      * @var boolean
      */
@@ -19,7 +18,6 @@ class QuoteHandler
 
     /**
      * QuoteHandler constructor.
-     * @param callable $quoteFn
      * @param bool $autoQuoteIdentifiers
      */
     public function __construct(callable $quoteFn, $autoQuoteIdentifiers = true)
@@ -51,7 +49,7 @@ class QuoteHandler
             case (is_numeric($value) && (string)($value + 0) === (string)$value):
                 $value = $value + 0;
                 break;
-            case is_null($value):
+            case $value === null:
                 $value = 'NULL';
                 break;
             case is_array($value):
@@ -180,7 +178,7 @@ class QuoteHandler
     {
         if ($auto === false || $this->autoQuoteIdentifiers === true) {
             $q = '`';
-            return ($q . str_replace("$q", "$q$q", $value) . $q);
+            return ($q . str_replace("{$q}", "{$q}{$q}", $value) . $q);
         }
 
         return $value;

--- a/src/Adapter/QuoteHandler.php
+++ b/src/Adapter/QuoteHandler.php
@@ -12,15 +12,18 @@ class QuoteHandler
     private $autoQuoteIdentifiers = true;
 
     /**
-     * @var callable
+     * @var \Closure
      */
     private $quoteFn;
 
     /**
-     * QuoteHandler constructor.
+     * @param \Closure $quoteFn {
+     *   @var mixed $value
+     *   @return string
+     * }
      * @param bool $autoQuoteIdentifiers
      */
-    public function __construct(callable $quoteFn, $autoQuoteIdentifiers = true)
+    public function __construct(\Closure $quoteFn, $autoQuoteIdentifiers = true)
     {
         $this->quoteFn = $quoteFn;
         $this->autoQuoteIdentifiers = $autoQuoteIdentifiers;
@@ -30,11 +33,10 @@ class QuoteHandler
      * Quote a database value.
      *
      * @param string $value
-     * @param integer $type
      * @return string
      * @throws InvalidArgumentException
      */
-    public function value($value, $type = null)
+    public function value($value)
     {
         switch (true) {
             case is_object($value):
@@ -62,7 +64,7 @@ class QuoteHandler
                 $value = implode(', ', $value);
                 break;
             default:
-                $value = call_user_func($this->quoteFn, $value, $type);
+                $value = ($this->quoteFn)($value);
         }
 
         return $value;
@@ -73,12 +75,11 @@ class QuoteHandler
      *
      * @param string $text
      * @param mixed $value
-     * @param string $type
      * @return string
      */
-    public function into($text, $value, $type = null)
+    public function into($text, $value)
     {
-        return str_replace('?', $this->value($value, $type), $text);
+        return str_replace('?', $this->value($value), $text);
     }
 
     /**

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -1,165 +1,56 @@
 <?php
 
-namespace Phlib\Db;
+declare(strict_types=1);
 
-use Phlib\Db\Exception\UnknownDatabaseException;
+namespace Phlib\Db;
 
 interface AdapterInterface
 {
-    /**
-     * Sets the item which creates a new DB connection.
-     * @return $this
-     */
-    public function setConnectionFactory(callable $factory);
+    public function setConnectionFactory(callable $factory): self;
 
-    /**
-     * Get the database connection.
-     *
-     * @return \PDO
-     */
-    public function getConnection();
+    public function getConnection(): \PDO;
 
-    /**
-     * Set the database connection.
-     *
-     * @return $this
-     */
-    public function setConnection(\PDO $connection);
+    public function setConnection(\PDO $connection): self;
 
-    /**
-     * Reconnects the database connection.
-     *
-     * @return $this
-     */
-    public function reconnect();
+    public function reconnect(): self;
 
-    /**
-     * Close connection
-     *
-     * @return void
-     */
-    public function closeConnection();
+    public function closeConnection(): void;
 
-    /**
-     * Clone connection
-     *
-     * @return \PDO
-     */
-    public function cloneConnection();
+    public function cloneConnection(): \PDO;
 
-    /**
-     * Magic method to clone the object.
-     */
     public function __clone();
 
-    /**
-     * Get the config for the database connection. This could be empty if the
-     * object was created with an empty array.
-     *
-     * @return array
-     */
-    public function getConfig();
+    public function getConfig(): array;
 
-    /**
-     * Set database
-     *
-     * @param string $dbname
-     * @return $this
-     * @throws UnknownDatabaseException
-     */
-    public function setDatabase($dbname);
+    public function setDatabase(string $dbname): self;
 
-    /**
-     * Set the character set on the connection.
-     *
-     * @param string $charset
-     * @return $this
-     */
-    public function setCharset($charset);
+    public function setCharset(string $charset): self;
 
-    /**
-     * Set the timezone on the connection.
-     *
-     * @param string $timezone
-     * @return $this
-     */
-    public function setTimezone($timezone);
+    public function setTimezone(string $timezone): self;
 
-    /**
-     * Enable connection buffering on queries.
-     *
-     * @return $this
-     */
-    public function enableBuffering();
+    public function enableBuffering(): self;
 
-    /**
-     * Disable connection buffering on queries.
-     *
-     * @return $this
-     */
-    public function disableBuffering();
+    public function disableBuffering(): self;
 
-    /**
-     * Returns whether the connection is set to buffered or not. By default
-     * it's true, all results are buffered.
-     *
-     * @return boolean
-     */
-    public function isBuffered();
+    public function isBuffered(): bool;
 
-    /**
-     * Ping the database connection to make sure the connection is still alive.
-     *
-     * @return boolean
-     */
-    public function ping();
+    public function ping(): bool;
 
     /**
      * Get the last inserted id. If the tablename is provided the id returned is
      * the last insert id will be for that table.
-     *
-     * @param string $tablename
-     * @return integer
      */
-    public function lastInsertId($tablename = null);
+    public function lastInsertId(string $tablename = null): string;
 
-    /**
-     * Prepare an SQL statement for execution.
-     *
-     * @param string $statement
-     * @return \PDOStatement
-     */
-    public function prepare($statement);
+    public function prepare(string $statement): \PDOStatement;
 
-    /**
-     * Execute an SQL statement
-     *
-     * @param string $statement
-     * @return int
-     */
-    public function execute($statement, array $bind = []);
+    public function execute(string $statement, array $bind = []): int;
 
-    /**
-     * Query the database.
-     *
-     * @param string $sql
-     * @throws \PDOException
-     * @return \PDOStatement
-     */
-    public function query($sql, array $bind = []);
+    public function query(string $sql, array $bind = []): \PDOStatement;
 
-    /**
-     * @return bool
-     */
-    public function beginTransaction();
+    public function beginTransaction(): bool;
 
-    /**
-     * @return bool
-     */
-    public function commit();
+    public function commit(): bool;
 
-    /**
-     * @return bool
-     */
-    public function rollBack();
+    public function rollBack(): bool;
 }

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -8,7 +8,6 @@ interface AdapterInterface
 {
     /**
      * Sets the item which creates a new DB connection.
-     * @param callable $factory
      * @return $this
      */
     public function setConnectionFactory(callable $factory);
@@ -23,7 +22,6 @@ interface AdapterInterface
     /**
      * Set the database connection.
      *
-     * @param \PDO $connection
      * @return $this
      */
     public function setConnection(\PDO $connection);
@@ -137,7 +135,6 @@ interface AdapterInterface
      * Execute an SQL statement
      *
      * @param string $statement
-     * @param array $bind
      * @return int
      */
     public function execute($statement, array $bind = []);
@@ -146,7 +143,6 @@ interface AdapterInterface
      * Query the database.
      *
      * @param string $sql
-     * @param array $bind
      * @throws \PDOException
      * @return \PDOStatement
      */

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Exception;
 
 interface Exception

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements Exception

--- a/src/Exception/InvalidQueryException.php
+++ b/src/Exception/InvalidQueryException.php
@@ -34,7 +34,7 @@ class InvalidQueryException extends RuntimeException implements Exception
         $code = 0;
         if ($previous !== null) {
             $message = $previous->getMessage();
-            $code = $previous->getCode();
+            $code = (int)$previous->getCode();
         }
         $message .= ' SQL: ' . $query . ' Bind: ' . var_export($bind, true);
 

--- a/src/Exception/InvalidQueryException.php
+++ b/src/Exception/InvalidQueryException.php
@@ -15,7 +15,6 @@ class InvalidQueryException extends RuntimeException implements Exception
     private $bind;
 
     /**
-     * @param \PDOException $exception
      * @return bool
      */
     public static function isInvalidSyntax(\PDOException $exception)
@@ -25,19 +24,17 @@ class InvalidQueryException extends RuntimeException implements Exception
 
     /**
      * @param string $query
-     * @param array $bind
-     * @param \PDOException|null $previous
      */
     public function __construct($query, array $bind = [], \PDOException $previous = null)
     {
         $this->query = $query;
-        $this->bind  = $bind;
+        $this->bind = $bind;
 
         $message = 'You have an error in your SQL syntax.';
-        $code    = 0;
-        if (!is_null($previous)) {
+        $code = 0;
+        if ($previous !== null) {
             $message = $previous->getMessage();
-            $code    = $previous->getCode();
+            $code = $previous->getCode();
         }
         $message .= ' SQL: ' . $query . ' Bind: ' . var_export($bind, true);
 

--- a/src/Exception/InvalidQueryException.php
+++ b/src/Exception/InvalidQueryException.php
@@ -1,31 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Exception;
 
 class InvalidQueryException extends RuntimeException implements Exception
 {
-    /**
-     * @var string
-     */
-    private $query;
+    private string $query;
 
-    /**
-     * @var array
-     */
-    private $bind;
+    private array $bind;
 
-    /**
-     * @return bool
-     */
-    public static function isInvalidSyntax(\PDOException $exception)
+    public static function isInvalidSyntax(\PDOException $exception): bool
     {
         return stripos($exception->getMessage(), 'You have an error in your SQL syntax') !== false;
     }
 
-    /**
-     * @param string $query
-     */
-    public function __construct($query, array $bind = [], \PDOException $previous = null)
+    public function __construct(string $query, array $bind = [], \PDOException $previous = null)
     {
         $this->query = $query;
         $this->bind = $bind;
@@ -41,18 +31,12 @@ class InvalidQueryException extends RuntimeException implements Exception
         parent::__construct($message, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
-    public function getQuery()
+    public function getQuery(): string
     {
         return $this->query;
     }
 
-    /**
-     * @return array
-     */
-    public function getBindData()
+    public function getBindData(): array
     {
         return $this->bind;
     }

--- a/src/Exception/OutOfRangeException.php
+++ b/src/Exception/OutOfRangeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Exception;
 
 class OutOfRangeException extends \OutOfRangeException implements Exception

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -5,7 +5,6 @@ namespace Phlib\Db\Exception;
 class RuntimeException extends \PDOException implements Exception
 {
     /**
-     * @param \PDOException $exception
      * @return static
      */
     public static function createFromException(\PDOException $exception)
@@ -20,7 +19,6 @@ class RuntimeException extends \PDOException implements Exception
     }
 
     /**
-     * @param \PDOException $exception
      * @return bool
      */
     public static function hasServerGoneAway(\PDOException $exception)

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,13 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Exception;
 
 class RuntimeException extends \PDOException implements Exception
 {
-    /**
-     * @return static
-     */
-    public static function createFromException(\PDOException $exception)
+    public static function createFromException(\PDOException $exception): self
     {
         if ($exception instanceof static) {
             return $exception;
@@ -18,10 +17,7 @@ class RuntimeException extends \PDOException implements Exception
         return $newSelf;
     }
 
-    /**
-     * @return bool
-     */
-    public static function hasServerGoneAway(\PDOException $exception)
+    public static function hasServerGoneAway(\PDOException $exception): bool
     {
         return stripos($exception->getMessage(), 'MySQL server has gone away') !== false;
     }

--- a/src/Exception/UnknownDatabaseException.php
+++ b/src/Exception/UnknownDatabaseException.php
@@ -33,10 +33,10 @@ class UnknownDatabaseException extends RuntimeException implements Exception
 
     public static function isUnknownDatabase(\PDOException $exception): bool
     {
-        return $exception->getCode() == self::ER_BAD_DB_ERROR_1 ||
+        return (int)$exception->getCode() === self::ER_BAD_DB_ERROR_1 ||
         (
-            $exception->getCode() == self::ER_BAD_DB_ERROR_2 &&
-            preg_match('/SQLSTATE\[42000\].*\s1049\s/', $exception->getMessage()) != false
+            (int)$exception->getCode() === self::ER_BAD_DB_ERROR_2 &&
+            preg_match('/SQLSTATE\[42000\].*\s1049\s/', $exception->getMessage()) === 1
         );
     }
 

--- a/src/Exception/UnknownDatabaseException.php
+++ b/src/Exception/UnknownDatabaseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Exception;
 
 class UnknownDatabaseException extends RuntimeException implements Exception
@@ -22,24 +24,14 @@ class UnknownDatabaseException extends RuntimeException implements Exception
      */
     public const ER_BAD_DB_ERROR_2 = 42000;
 
-    /**
-     * @var string
-     */
-    private $name;
+    private string $name;
 
-    /**
-     * @param string $database
-     * @return static
-     */
-    public static function createFromUnknownDatabase($database, \PDOException $exception)
+    public static function createFromUnknownDatabase(string $database, \PDOException $exception): self
     {
         return new static($database, "Unknown database '{$database}'.", self::ER_BAD_DB_ERROR_1, $exception);
     }
 
-    /**
-     * @return bool
-     */
-    public static function isUnknownDatabase(\PDOException $exception)
+    public static function isUnknownDatabase(\PDOException $exception): bool
     {
         return $exception->getCode() == self::ER_BAD_DB_ERROR_1 ||
         (
@@ -48,22 +40,13 @@ class UnknownDatabaseException extends RuntimeException implements Exception
         );
     }
 
-    /**
-     * UnknownDatabaseException constructor.
-     * @param string $database
-     * @param string $message
-     * @param int $code
-     */
-    public function __construct($database, $message, $code = 0, \PDOException $previous = null)
+    public function __construct(string $database, string $message, int $code = 0, \PDOException $previous = null)
     {
         $this->name = $database;
         parent::__construct($message, $code, $previous);
     }
 
-    /**
-     * @return string
-     */
-    public function getDatabaseName()
+    public function getDatabaseName(): string
     {
         return $this->name;
     }

--- a/src/Exception/UnknownDatabaseException.php
+++ b/src/Exception/UnknownDatabaseException.php
@@ -10,13 +10,17 @@ class UnknownDatabaseException extends RuntimeException implements Exception
      * ::construct - dbname=<dbname>
      * Code: 1049
      * Err:  SQLSTATE[HY000] [1049] Unknown database '<dbname>'
+     */
+    public const ER_BAD_DB_ERROR_1 = 1049;
+
+    /**
+     * http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
      *
      * ::query USE <dbname>
      * Code: 42000
      * Err:  SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '<dbname>'
      */
-    const ER_BAD_DB_ERROR_1 = 1049;
-    const ER_BAD_DB_ERROR_2 = 42000;
+    public const ER_BAD_DB_ERROR_2 = 42000;
 
     /**
      * @var string
@@ -25,7 +29,6 @@ class UnknownDatabaseException extends RuntimeException implements Exception
 
     /**
      * @param string $database
-     * @param \PDOException $exception
      * @return static
      */
     public static function createFromUnknownDatabase($database, \PDOException $exception)
@@ -34,7 +37,6 @@ class UnknownDatabaseException extends RuntimeException implements Exception
     }
 
     /**
-     * @param \PDOException $exception
      * @return bool
      */
     public static function isUnknownDatabase(\PDOException $exception)
@@ -51,7 +53,6 @@ class UnknownDatabaseException extends RuntimeException implements Exception
      * @param string $database
      * @param string $message
      * @param int $code
-     * @param \PDOException|null $previous
      */
     public function __construct($database, $message, $code = 0, \PDOException $previous = null)
     {

--- a/src/SqlFragment.php
+++ b/src/SqlFragment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db;
 
 /**
@@ -8,23 +10,14 @@ namespace Phlib\Db;
  */
 class SqlFragment
 {
-    /**
-     * @var string
-     */
-    private $value;
+    private string $value;
 
-    /**
-     * @param string $value SQL expression
-     */
-    public function __construct($value)
+    public function __construct(string $value)
     {
-        $this->value = (string)$value;
+        $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->value;
     }

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\Config;
@@ -9,16 +11,15 @@ use PHPUnit\Framework\TestCase;
 class ConfigTest extends TestCase
 {
     /**
-     * @param string $expectedElement
      * @dataProvider getDsnDataProvider
      */
-    public function testGetDsn(array $dsnConfig, $expectedElement)
+    public function testGetDsn(array $dsnConfig, string $expectedElement): void
     {
         $config = new Config($dsnConfig);
         static::assertContains($dsnConfig[$expectedElement], $config->getDsn());
     }
 
-    public function getDsnDataProvider()
+    public function getDsnDataProvider(): array
     {
         return [
             [['host' => '127.0.0.1'], 'host'],
@@ -27,7 +28,7 @@ class ConfigTest extends TestCase
         ];
     }
 
-    public function testGetDsnWithoutHost()
+    public function testGetDsnWithoutHost(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -36,12 +37,10 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @param string $method
-     * @param string $element
      * @param mixed $value
      * @dataProvider getMethodsDataProvider
      */
-    public function testGetMethods($method, $element, $value)
+    public function testGetMethods(string $method, string $element, $value): void
     {
         $config = new Config([
             $element => $value,
@@ -49,7 +48,7 @@ class ConfigTest extends TestCase
         static::assertEquals($value, $config->{$method}());
     }
 
-    public function getMethodsDataProvider()
+    public function getMethodsDataProvider(): array
     {
         return [
             ['getUsername', 'username', 'foo'],
@@ -61,18 +60,17 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @param int $element
-     * @param string $expected
+     * @param mixed $expected
      * @dataProvider getOptionsDataProvider
      */
-    public function testGetOptions(array $data, $element, $expected)
+    public function testGetOptions(array $data, int $element, $expected): void
     {
         $options = (new Config($data))->getOptions();
         static::assertArrayHasKey($element, $options);
         static::assertEquals($expected, $options[$element]);
     }
 
-    public function getOptionsDataProvider()
+    public function getOptionsDataProvider(): array
     {
         return [
             [['timeout' => 10], \PDO::ATTR_TIMEOUT, 10],
@@ -86,11 +84,9 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @param int $expected
-     * @param int $value
      * @dataProvider getMaximumAttemptsDataProvider
      */
-    public function testGetMaximumAttempts($value, $expected)
+    public function testGetMaximumAttempts(int $value, int $expected): void
     {
         $config = new Config([
             'retryCount' => $value,
@@ -98,7 +94,7 @@ class ConfigTest extends TestCase
         static::assertEquals($expected, $config->getMaximumAttempts());
     }
 
-    public function getMaximumAttemptsDataProvider()
+    public function getMaximumAttemptsDataProvider(): array
     {
         return [
             [-1, 1],

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -45,7 +45,7 @@ class ConfigTest extends TestCase
         $config = new Config([
             $element => $value,
         ]);
-        static::assertEquals($value, $config->{$method}());
+        static::assertSame($value, $config->{$method}());
     }
 
     public function getMethodsDataProvider(): array
@@ -67,7 +67,7 @@ class ConfigTest extends TestCase
     {
         $options = (new Config($data))->getOptions();
         static::assertArrayHasKey($element, $options);
-        static::assertEquals($expected, $options[$element]);
+        static::assertSame($expected, $options[$element]);
     }
 
     public function getOptionsDataProvider(): array
@@ -91,7 +91,7 @@ class ConfigTest extends TestCase
         $config = new Config([
             'retryCount' => $value,
         ]);
-        static::assertEquals($expected, $config->getMaximumAttempts());
+        static::assertSame($expected, $config->getMaximumAttempts());
     }
 
     public function getMaximumAttemptsDataProvider(): array

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -3,8 +3,9 @@
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\Config;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * @param array $dsnConfig
@@ -14,7 +15,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testGetDsn(array $dsnConfig, $expectedElement)
     {
         $config = new Config($dsnConfig);
-        $this->assertContains($dsnConfig[$expectedElement], $config->getDsn());
+        static::assertContains($dsnConfig[$expectedElement], $config->getDsn());
     }
 
     public function getDsnDataProvider()
@@ -44,7 +45,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testGetMethods($method, $element, $value)
     {
         $config = new Config([$element => $value]);
-        $this->assertEquals($value, $config->$method());
+        static::assertEquals($value, $config->$method());
     }
 
     public function getMethodsDataProvider()
@@ -67,8 +68,8 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testGetOptions(array $data, $element, $expected)
     {
         $options = (new Config($data))->getOptions();
-        $this->assertArrayHasKey($element, $options);
-        $this->assertEquals($expected, $options[$element]);
+        static::assertArrayHasKey($element, $options);
+        static::assertEquals($expected, $options[$element]);
     }
 
     public function getOptionsDataProvider()
@@ -91,7 +92,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetMaximumAttempts($value, $expected)
     {
-        $this->assertEquals($expected, (new Config(['retryCount' => $value]))->getMaximumAttempts());
+        static::assertEquals($expected, (new Config(['retryCount' => $value]))->getMaximumAttempts());
     }
 
     public function getMaximumAttemptsDataProvider()

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\TestCase;
 class ConfigTest extends TestCase
 {
     /**
-     * @param array $dsnConfig
      * @param string $expectedElement
      * @dataProvider getDsnDataProvider
      */
@@ -44,8 +43,10 @@ class ConfigTest extends TestCase
      */
     public function testGetMethods($method, $element, $value)
     {
-        $config = new Config([$element => $value]);
-        static::assertEquals($value, $config->$method());
+        $config = new Config([
+            $element => $value,
+        ]);
+        static::assertEquals($value, $config->{$method}());
     }
 
     public function getMethodsDataProvider()
@@ -60,7 +61,6 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @param array $data
      * @param int $element
      * @param string $expected
      * @dataProvider getOptionsDataProvider
@@ -81,7 +81,7 @@ class ConfigTest extends TestCase
             [['timeout' => ''], \PDO::ATTR_TIMEOUT, 2], // default
             [['timeout' => 121], \PDO::ATTR_TIMEOUT, 2], // max
             [[], \PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION],
-            [[], \PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC]
+            [[], \PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC],
         ];
     }
 
@@ -92,7 +92,10 @@ class ConfigTest extends TestCase
      */
     public function testGetMaximumAttempts($value, $expected)
     {
-        static::assertEquals($expected, (new Config(['retryCount' => $value]))->getMaximumAttempts());
+        $config = new Config([
+            'retryCount' => $value,
+        ]);
+        static::assertEquals($expected, $config->getMaximumAttempts());
     }
 
     public function getMaximumAttemptsDataProvider()

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -3,6 +3,7 @@
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\Config;
+use Phlib\Db\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
@@ -27,11 +28,10 @@ class ConfigTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Phlib\Db\Exception\InvalidArgumentException
-     */
     public function testGetDsnWithoutHost()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $config = new Config([]);
         $config->getDsn();
     }

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -16,7 +16,7 @@ class ConfigTest extends TestCase
     public function testGetDsn(array $dsnConfig, string $expectedElement): void
     {
         $config = new Config($dsnConfig);
-        static::assertContains($dsnConfig[$expectedElement], $config->getDsn());
+        static::assertStringContainsString($dsnConfig[$expectedElement], $config->getDsn());
     }
 
     public function getDsnDataProvider(): array

--- a/tests/Adapter/ConnectionFactoryTest.php
+++ b/tests/Adapter/ConnectionFactoryTest.php
@@ -2,8 +2,8 @@
 
 namespace Phlib\Db\Tests\Adapter;
 
-use Phlib\Db\Adapter\ConnectionFactory;
 use Phlib\Db\Adapter\Config;
+use Phlib\Db\Adapter\ConnectionFactory;
 use Phlib\Db\Exception\RuntimeException;
 use Phlib\Db\Exception\UnknownDatabaseException;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,8 +28,8 @@ class ConnectionFactoryTest extends TestCase
 
     protected function setUp()
     {
-        $this->config  = $this->createMock(Config::class);
-        $this->pdo     = $this->createMock(\PDO::class);
+        $this->config = $this->createMock(Config::class);
+        $this->pdo = $this->createMock(\PDO::class);
         $this->factory = $this->createPartialMock(ConnectionFactory::class, ['create']);
 
         parent::setUp();
@@ -76,7 +76,7 @@ class ConnectionFactoryTest extends TestCase
     {
         return [
             ['getCharset', 'latin1'],
-            ['getTimezone', '+0200']
+            ['getTimezone', '+0200'],
         ];
     }
 
@@ -117,7 +117,7 @@ class ConnectionFactoryTest extends TestCase
         return [
             [1],
             [2],
-            [3]
+            [3],
         ];
     }
 

--- a/tests/Adapter/ConnectionFactoryTest.php
+++ b/tests/Adapter/ConnectionFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\Config;
@@ -15,19 +17,19 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @var Config|MockObject
      */
-    private $config;
+    private MockObject $config;
 
     /**
      * @var \PDO|MockObject
      */
-    private $pdo;
+    private MockObject $pdo;
 
     /**
      * @var ConnectionFactory|MockObject
      */
-    private $factory;
+    private MockObject $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->config = $this->createMock(Config::class);
         $this->pdo = $this->createMock(\PDO::class);
@@ -36,7 +38,7 @@ class ConnectionFactoryTest extends TestCase
         parent::setUp();
     }
 
-    public function testGettingConnection()
+    public function testGettingConnection(): void
     {
         $this->factory->method('create')
             ->willReturn($this->pdo);
@@ -51,11 +53,9 @@ class ConnectionFactoryTest extends TestCase
     }
 
     /**
-     * @param string $method
-     * @param string $value
      * @dataProvider charsetIsSetOnConnectionDataProvider
      */
-    public function testCharsetIsSetOnConnection($method, $value)
+    public function testCharsetIsSetOnConnection(string $method, string $value): void
     {
         $this->factory->method('create')
             ->willReturn($this->pdo);
@@ -73,7 +73,7 @@ class ConnectionFactoryTest extends TestCase
         static::assertSame($this->pdo, $this->factory->__invoke($this->config));
     }
 
-    public function charsetIsSetOnConnectionDataProvider()
+    public function charsetIsSetOnConnectionDataProvider(): array
     {
         return [
             ['getCharset', 'latin1'],
@@ -81,7 +81,7 @@ class ConnectionFactoryTest extends TestCase
         ];
     }
 
-    public function testSettingUnknownDatabase()
+    public function testSettingUnknownDatabase(): void
     {
         $this->expectException(UnknownDatabaseException::class);
 
@@ -96,10 +96,9 @@ class ConnectionFactoryTest extends TestCase
     }
 
     /**
-     * @param int $attempts
      * @dataProvider exceedingNumberOfAttemptsDataProvider
      */
-    public function testExceedingNumberOfAttempts($attempts)
+    public function testExceedingNumberOfAttempts(int $attempts): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -113,7 +112,7 @@ class ConnectionFactoryTest extends TestCase
         $this->factory->__invoke($this->config);
     }
 
-    public function exceedingNumberOfAttemptsDataProvider()
+    public function exceedingNumberOfAttemptsDataProvider(): array
     {
         return [
             [1],
@@ -122,7 +121,7 @@ class ConnectionFactoryTest extends TestCase
         ];
     }
 
-    public function testFailedAttemptThenSucceeds()
+    public function testFailedAttemptThenSucceeds(): void
     {
         $this->factory->method('create')
             ->willReturn($this->pdo);

--- a/tests/Adapter/ConnectionFactoryTest.php
+++ b/tests/Adapter/ConnectionFactoryTest.php
@@ -4,22 +4,25 @@ namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\ConnectionFactory;
 use Phlib\Db\Adapter\Config;
+use Phlib\Db\Exception\RuntimeException;
+use Phlib\Db\Exception\UnknownDatabaseException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ConnectionFactoryTest extends TestCase
 {
     /**
-     * @var Config|\PHPUnit_Framework_MockObject_MockObject
+     * @var Config|MockObject
      */
     private $config;
 
     /**
-     * @var \PDO|\PHPUnit_Framework_MockObject_MockObject
+     * @var \PDO|MockObject
      */
     private $pdo;
 
     /**
-     * @var ConnectionFactory|\PHPUnit_Framework_MockObject_MockObject
+     * @var ConnectionFactory|MockObject
      */
     private $factory;
 
@@ -77,11 +80,10 @@ class ConnectionFactoryTest extends TestCase
         ];
     }
 
-    /**
-     * @expectedException \Phlib\Db\Exception\UnknownDatabaseException
-     */
     public function testSettingUnknownDatabase()
     {
+        $this->expectException(UnknownDatabaseException::class);
+
         $this->factory->method('create')
             ->willThrowException(new \PDOException(
                 "SQLSTATE[HY000] [1049] Unknown database '<dbname>'",
@@ -95,10 +97,11 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @param int $attempts
      * @dataProvider exceedingNumberOfAttemptsDataProvider
-     * @expectedException \Phlib\Db\Exception\RuntimeException
      */
     public function testExceedingNumberOfAttempts($attempts)
     {
+        $this->expectException(RuntimeException::class);
+
         $this->factory->method('create')
             ->willThrowException(new \PDOException(
                 "SQLSTATE[HY000] [1049] Unknown database '<dbname>'",

--- a/tests/Adapter/ConnectionFactoryTest.php
+++ b/tests/Adapter/ConnectionFactoryTest.php
@@ -62,7 +62,7 @@ class ConnectionFactoryTest extends TestCase
 
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->method('execute')
-            ->with(static::contains($value));
+            ->with(static::containsIdentical($value));
         $this->pdo->method('prepare')
             ->willReturn($pdoStatement);
 

--- a/tests/Adapter/ConnectionFactoryTest.php
+++ b/tests/Adapter/ConnectionFactoryTest.php
@@ -6,6 +6,7 @@ use Phlib\Db\Adapter\Config;
 use Phlib\Db\Adapter\ConnectionFactory;
 use Phlib\Db\Exception\RuntimeException;
 use Phlib\Db\Exception\UnknownDatabaseException;
+use Phlib\Db\Tests\Exception\PDOExceptionStub;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -85,7 +86,7 @@ class ConnectionFactoryTest extends TestCase
         $this->expectException(UnknownDatabaseException::class);
 
         $this->factory->method('create')
-            ->willThrowException(new \PDOException(
+            ->willThrowException(new PDOExceptionStub(
                 "SQLSTATE[HY000] [1049] Unknown database '<dbname>'",
                 1049
             ));
@@ -103,7 +104,7 @@ class ConnectionFactoryTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $this->factory->method('create')
-            ->willThrowException(new \PDOException(
+            ->willThrowException(new PDOExceptionStub(
                 "SQLSTATE[HY000] [1049] Unknown database '<dbname>'",
                 1049
             ));

--- a/tests/Adapter/CrudTraitTest.php
+++ b/tests/Adapter/CrudTraitTest.php
@@ -5,12 +5,13 @@ namespace Phlib\Db\Tests\Adapter;
 use Phlib\Db\Adapter\CrudTrait;
 use Phlib\Db\Adapter\QuoteHandler;
 use Phlib\Db\SqlFragment;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class CrudTraitTest extends TestCase
 {
     /**
-     * @var CrudTrait|\PHPUnit_Framework_MockObject_MockObject
+     * @var CrudTrait|MockObject
      */
     private $crud;
 

--- a/tests/Adapter/CrudTraitTest.php
+++ b/tests/Adapter/CrudTraitTest.php
@@ -33,7 +33,6 @@ class CrudTraitTest extends TestCase
     /**
      * @param string $expectedSql
      * @param string $table
-     * @param array $where
      * @dataProvider selectDataProvider
      */
     public function testSelect($expectedSql, $table, array $where)
@@ -53,18 +52,29 @@ class CrudTraitTest extends TestCase
     public function selectDataProvider()
     {
         return [
-            ["SELECT * FROM `my_table`", 'my_table', []],
+            [
+                'SELECT * FROM `my_table`',
+                'my_table',
+                [],
+            ],
             [
                 "SELECT * FROM `table` WHERE col1 = 'v1' AND col2 = 'v2' AND col3 IS NULL",
                 'table',
-                ['col1 = ?' => 'v1', 'col2 = ?' => 'v2', 'col3 IS NULL'],
+                [
+                    'col1 = ?' => 'v1',
+                    'col2 = ?' => 'v2',
+                    'col3 IS NULL',
+                ],
             ],
             // Correct quote behaviour for number and object
             [
-                "SELECT * FROM `table` WHERE col1 = 123 AND col2 = col3",
+                'SELECT * FROM `table` WHERE col1 = 123 AND col2 = col3',
                 'table',
-                ['col1 = ?' => 123, 'col2 = ?' => new SqlFragment('col3')],
-            ]
+                [
+                    'col1 = ?' => 123,
+                    'col2 = ?' => new SqlFragment('col3'),
+                ],
+            ],
         ];
     }
 
@@ -80,7 +90,6 @@ class CrudTraitTest extends TestCase
     /**
      * @param string $expectedSql
      * @param string $table
-     * @param array $data
      * @dataProvider insertDataProvider
      */
     public function testInsert($expectedSql, $table, array $data)
@@ -101,12 +110,35 @@ class CrudTraitTest extends TestCase
     public function insertDataProvider()
     {
         return [
-            ["INSERT INTO `table` (`col1`) VALUES ('v1')", 'table', ['col1' => 'v1']],
-            ["INSERT INTO `table` (`col1`, `col2`) VALUES ('v1', 'v2')", 'table', ['col1' => 'v1', 'col2' => 'v2']],
+            [
+                "INSERT INTO `table` (`col1`) VALUES ('v1')",
+                'table',
+                [
+                    'col1' => 'v1',
+                ],
+            ],
+            [
+                "INSERT INTO `table` (`col1`, `col2`) VALUES ('v1', 'v2')",
+                'table',
+                [
+                    'col1' => 'v1',
+                    'col2' => 'v2',
+                ],
+            ],
             // Number should not be quoted
-            ["INSERT INTO `table` (`col1`) VALUES (123)", 'table', ['col1' => 123]],
+            [
+                'INSERT INTO `table` (`col1`) VALUES (123)',
+                'table', [
+                    'col1' => 123,
+                ],
+            ],
             // Object should be handled
-            ["INSERT INTO `table` (`col1`) VALUES (col2)", 'table', ['col1' => new SqlFragment('col2')]],
+            [
+                'INSERT INTO `table` (`col1`) VALUES (col2)',
+                'table', [
+                    'col1' => new SqlFragment('col2'),
+                ],
+            ],
         ];
     }
 
@@ -114,7 +146,6 @@ class CrudTraitTest extends TestCase
      * @param string $expectedSql
      * @param string $table
      * @param array $data
-     * @param array $where
      * @dataProvider updateDataProvider
      */
     public function testUpdate($expectedSql, $table, $data, array $where)
@@ -138,28 +169,53 @@ class CrudTraitTest extends TestCase
     public function updateDataProvider()
     {
         return [
-            ["UPDATE `table` SET `col1` = 'v1'", 'table', ['col1' => 'v1'], []],
-            ["UPDATE `table` SET `col1` = 'v1', `col2` = 'v2'", 'table', ['col1' => 'v1', 'col2' => 'v2'], []],
+            [
+                "UPDATE `table` SET `col1` = 'v1'",
+                'table',
+                [
+                    'col1' => 'v1',
+                ],
+                [],
+            ],
+            [
+                "UPDATE `table` SET `col1` = 'v1', `col2` = 'v2'",
+                'table',
+                [
+                    'col1' => 'v1',
+                    'col2' => 'v2',
+                ],
+                [],
+            ],
             [
                 "UPDATE `table` SET `col1` = 'v1' WHERE col3 = 'v3' AND col4 = 'v4' AND col5 IS NULL",
                 'table',
-                ['col1' => 'v1'],
-                ['col3 = ?' => 'v3', 'col4 = ?' => 'v4', 'col5 IS NULL'],
+                [
+                    'col1' => 'v1',
+                ],
+                [
+                    'col3 = ?' => 'v3',
+                    'col4 = ?' => 'v4',
+                    'col5 IS NULL',
+                ],
             ],
             // Correct quote behaviour for number and object
             [
                 "UPDATE `table` SET `col1` = 'v1' WHERE col3 = 123 AND col4 = col2",
                 'table',
-                ['col1' => 'v1'],
-                ['col3 = ?' => 123, 'col4 = ?' => new SqlFragment('col2')],
-            ]
+                [
+                    'col1' => 'v1',
+                ],
+                [
+                    'col3 = ?' => 123,
+                    'col4 = ?' => new SqlFragment('col2'),
+                ],
+            ],
         ];
     }
 
     /**
      * @param string $expectedSql
      * @param string $table
-     * @param array $where
      * @dataProvider deleteDataProvider
      */
     public function testDelete($expectedSql, $table, array $where)
@@ -183,18 +239,29 @@ class CrudTraitTest extends TestCase
     public function deleteDataProvider()
     {
         return [
-            ["DELETE FROM `table`", 'table', []],
+            [
+                'DELETE FROM `table`',
+                'table',
+                [],
+            ],
             [
                 "DELETE FROM `table` WHERE col1 = 'v1' AND col2 = 'v2' AND col3 IS NULL",
                 'table',
-                ['col1 = ?' => 'v1', 'col2 = ?' => 'v2', 'col3 IS NULL'],
+                [
+                    'col1 = ?' => 'v1',
+                    'col2 = ?' => 'v2',
+                    'col3 IS NULL',
+                ],
             ],
             // Correct quote behaviour for number and object
             [
-                "DELETE FROM `table` WHERE col1 = 123 AND col2 = col3",
+                'DELETE FROM `table` WHERE col1 = 123 AND col2 = col3',
                 'table',
-                ['col1 = ?' => 123, 'col2 = ?' => new SqlFragment('col3')],
-            ]
+                [
+                    'col1 = ?' => 123,
+                    'col2 = ?' => new SqlFragment('col3'),
+                ],
+            ],
         ];
     }
 
@@ -222,12 +289,38 @@ class CrudTraitTest extends TestCase
     public function upsertDataProvider()
     {
         return [
-            ["INSERT INTO `table` (`col1`) VALUES (?) ON DUPLICATE KEY UPDATE `col1` = VALUES(`col1`)",
-                'table', ['col1' => 'v1'], ['col1']],
-            ["INSERT INTO `table` (`col1`, `col2`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `col1` = VALUES(`col1`)",
-                'table', ['col1' => 'v1', 'col2' => 'v2'], ['col1']],
-            ["INSERT INTO `table` (`col1`, `col2`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `col1` = VALUES(`col1`), `col2` = VALUES(`col2`)",
-                'table', ['col1' => 'v1', 'col2' => 'v2'], ['col1', 'col2']],
+            [
+                'INSERT INTO `table` (`col1`) VALUES (?) ON DUPLICATE KEY UPDATE `col1` = VALUES(`col1`)',
+                'table',
+                [
+                    'col1' => 'v1',
+                ],
+                [
+                    'col1',
+                ],
+            ],
+            [
+                'INSERT INTO `table` (`col1`, `col2`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `col1` = VALUES(`col1`)',
+                'table',
+                [
+                    'col1' => 'v1',
+                    'col2' => 'v2',
+                ], [
+                    'col1',
+                ],
+            ],
+            [
+                'INSERT INTO `table` (`col1`, `col2`) VALUES (?, ?) ON DUPLICATE KEY UPDATE `col1` = VALUES(`col1`), `col2` = VALUES(`col2`)',
+                'table',
+                [
+                    'col1' => 'v1',
+                    'col2' => 'v2',
+                ],
+                [
+                    'col1',
+                    'col2',
+                ],
+            ],
         ];
     }
 }

--- a/tests/Adapter/CrudTraitTest.php
+++ b/tests/Adapter/CrudTraitTest.php
@@ -287,7 +287,7 @@ class CrudTraitTest extends TestCase
             ->with($expectedSql, $bind)
             ->willReturn($pdoStatement);
 
-        static::assertEquals(1, $this->crud->upsert($table, $data, $updateFields));
+        static::assertSame(1, $this->crud->upsert($table, $data, $updateFields));
     }
 
     public function upsertDataProvider(): array

--- a/tests/Adapter/CrudTraitTest.php
+++ b/tests/Adapter/CrudTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\CrudTrait;
@@ -13,9 +15,9 @@ class CrudTraitTest extends TestCase
     /**
      * @var CrudTrait|MockObject
      */
-    private $crud;
+    private MockObject $crud;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -31,11 +33,9 @@ class CrudTraitTest extends TestCase
     }
 
     /**
-     * @param string $expectedSql
-     * @param string $table
      * @dataProvider selectDataProvider
      */
-    public function testSelect($expectedSql, $table, array $where)
+    public function testSelect(string $expectedSql, string $table, array $where): void
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
 
@@ -49,7 +49,7 @@ class CrudTraitTest extends TestCase
             $this->crud->select($table);
     }
 
-    public function selectDataProvider()
+    public function selectDataProvider(): array
     {
         return [
             [
@@ -78,7 +78,7 @@ class CrudTraitTest extends TestCase
         ];
     }
 
-    public function testSelectReturnsStatement()
+    public function testSelectReturnsStatement(): void
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $this->crud->method('query')
@@ -88,26 +88,27 @@ class CrudTraitTest extends TestCase
     }
 
     /**
-     * @param string $expectedSql
-     * @param string $table
      * @dataProvider insertDataProvider
      */
-    public function testInsert($expectedSql, $table, array $data)
+    public function testInsert(string $expectedSql, string $table, array $data): void
     {
         // Returned stmt will have rowCount called
+        $rowCount = count($data);
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->expects(static::once())
             ->method('rowCount')
-            ->willReturn(count($data));
+            ->willReturn($rowCount);
 
         $this->crud->method('query')
             ->with($expectedSql, [])
             ->willReturn($pdoStatement);
 
-        $this->crud->insert($table, $data);
+        $actual = $this->crud->insert($table, $data);
+
+        static::assertSame($rowCount, $actual);
     }
 
-    public function insertDataProvider()
+    public function insertDataProvider(): array
     {
         return [
             [
@@ -143,17 +144,16 @@ class CrudTraitTest extends TestCase
     }
 
     /**
-     * @param string $expectedSql
-     * @param string $table
-     * @param array $data
      * @dataProvider updateDataProvider
      */
-    public function testUpdate($expectedSql, $table, $data, array $where)
+    public function testUpdate(string $expectedSql, string $table, array $data, array $where): void
     {
         // Returned stmt will have rowCount called
+        $rowCount = rand();
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->expects(static::once())
-            ->method('rowCount');
+            ->method('rowCount')
+            ->willReturn($rowCount);
 
         // Query should be called with the SQL and bind
         $this->crud->expects(static::once())
@@ -161,12 +161,14 @@ class CrudTraitTest extends TestCase
             ->with($expectedSql, [])
             ->willReturn($pdoStatement);
 
-        (!empty($where)) ?
+        $actual = (!empty($where)) ?
             $this->crud->update($table, $data, $where) :
             $this->crud->update($table, $data);
+
+        static::assertSame($rowCount, $actual);
     }
 
-    public function updateDataProvider()
+    public function updateDataProvider(): array
     {
         return [
             [
@@ -214,16 +216,16 @@ class CrudTraitTest extends TestCase
     }
 
     /**
-     * @param string $expectedSql
-     * @param string $table
      * @dataProvider deleteDataProvider
      */
-    public function testDelete($expectedSql, $table, array $where)
+    public function testDelete(string $expectedSql, string $table, array $where): void
     {
         // Returned stmt will have rowCount called
+        $rowCount = rand();
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->expects(static::once())
-            ->method('rowCount');
+            ->method('rowCount')
+            ->willReturn($rowCount);
 
         // Query should be called with the SQL and bind
         $this->crud->expects(static::once())
@@ -231,12 +233,14 @@ class CrudTraitTest extends TestCase
             ->with($expectedSql, [])
             ->willReturn($pdoStatement);
 
-        (!empty($where)) ?
+        $actual = (!empty($where)) ?
             $this->crud->delete($table, $where) :
             $this->crud->delete($table);
+
+        static::assertSame($rowCount, $actual);
     }
 
-    public function deleteDataProvider()
+    public function deleteDataProvider(): array
     {
         return [
             [
@@ -268,7 +272,7 @@ class CrudTraitTest extends TestCase
     /**
      * @dataProvider upsertDataProvider
      */
-    public function testUpsert($expectedSql, $table, array $data, array $updateFields)
+    public function testUpsert(string $expectedSql, string $table, array $data, array $updateFields): void
     {
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
@@ -286,7 +290,7 @@ class CrudTraitTest extends TestCase
         static::assertEquals(1, $this->crud->upsert($table, $data, $updateFields));
     }
 
-    public function upsertDataProvider()
+    public function upsertDataProvider(): array
     {
         return [
             [

--- a/tests/Adapter/CrudTraitTest.php
+++ b/tests/Adapter/CrudTraitTest.php
@@ -5,15 +5,16 @@ namespace Phlib\Db\Tests\Adapter;
 use Phlib\Db\Adapter\CrudTrait;
 use Phlib\Db\Adapter\QuoteHandler;
 use Phlib\Db\SqlFragment;
+use PHPUnit\Framework\TestCase;
 
-class CrudTraitTest extends \PHPUnit_Framework_TestCase
+class CrudTraitTest extends TestCase
 {
     /**
      * @var CrudTrait|\PHPUnit_Framework_MockObject_MockObject
      */
     private $crud;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 
@@ -28,12 +29,6 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
             ->willReturn($quoteHandler);
     }
 
-    public function tearDown()
-    {
-        $this->crud = null;
-        parent::tearDown();
-    }
-
     /**
      * @param string $expectedSql
      * @param string $table
@@ -44,10 +39,10 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
 
-        $this->crud->expects($this->once())
+        $this->crud->expects(static::once())
             ->method('query')
             ->with($expectedSql, [])
-            ->will($this->returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
 
         (!empty($where)) ?
             $this->crud->select($table, $where) :
@@ -75,11 +70,10 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     public function testSelectReturnsStatement()
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $this->crud->expects($this->any())
-            ->method('query')
-            ->will($this->returnValue($pdoStatement));
+        $this->crud->method('query')
+            ->willReturn($pdoStatement);
 
-        $this->assertSame($pdoStatement, $this->crud->select('my_table'));
+        static::assertSame($pdoStatement, $this->crud->select('my_table'));
     }
 
     /**
@@ -92,14 +86,13 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     {
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('rowCount')
-            ->will($this->returnValue(count($data)));
+            ->willReturn(count($data));
 
-        $this->crud->expects($this->any())
-            ->method('query')
+        $this->crud->method('query')
             ->with($expectedSql, [])
-            ->will($this->returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
 
         $this->crud->insert($table, $data);
     }
@@ -127,14 +120,14 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     {
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('rowCount');
 
         // Query should be called with the SQL and bind
-        $this->crud->expects($this->once())
+        $this->crud->expects(static::once())
             ->method('query')
             ->with($expectedSql, [])
-            ->will($this->returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
 
         (!empty($where)) ?
             $this->crud->update($table, $data, $where) :
@@ -172,14 +165,14 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     {
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('rowCount');
 
         // Query should be called with the SQL and bind
-        $this->crud->expects($this->once())
+        $this->crud->expects(static::once())
             ->method('query')
             ->with($expectedSql, [])
-            ->will($this->returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
 
         (!empty($where)) ?
             $this->crud->delete($table, $where) :
@@ -211,18 +204,18 @@ class CrudTraitTest extends \PHPUnit_Framework_TestCase
     {
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('rowCount')
             ->willReturn(1);
 
         $bind = array_values($data);
         // Query should be called with the SQL and bind
-        $this->crud->expects($this->once())
+        $this->crud->expects(static::once())
             ->method('query')
             ->with($expectedSql, $bind)
             ->willReturn($pdoStatement);
 
-        $this->assertEquals(1, $this->crud->upsert($table, $data, $updateFields));
+        static::assertEquals(1, $this->crud->upsert($table, $data, $updateFields));
     }
 
     public function upsertDataProvider()

--- a/tests/Adapter/QuoteHandlerTest.php
+++ b/tests/Adapter/QuoteHandlerTest.php
@@ -4,12 +4,13 @@ namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\QuoteHandler;
 use Phlib\Db\SqlFragment;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class QuoteHandlerTest extends TestCase
 {
     /**
-     * @var QuoteHandler|\PHPUnit_Framework_MockObject_MockObject
+     * @var QuoteHandler|MockObject
      */
     private $handler;
 

--- a/tests/Adapter/QuoteHandlerTest.php
+++ b/tests/Adapter/QuoteHandlerTest.php
@@ -17,7 +17,7 @@ class QuoteHandlerTest extends TestCase
     protected function setUp()
     {
         $this->handler = new QuoteHandler(function ($value) {
-            return "`$value`";
+            return "`{$value}`";
         });
         parent::setUp();
     }
@@ -70,13 +70,13 @@ class QuoteHandlerTest extends TestCase
     public function intoDataProvider()
     {
         return [
-            ["field = `value`", 'field = ?', 'value'],
+            ['field = `value`', 'field = ?', 'value'],
             ['field = 123', 'field = ?', 123],
             ['field IS NULL', 'field IS ?', null],
             ['field IN (1, 2, 3)', 'field IN (?)', [1, 2, 3]],
-            ["field IN (`one`, `two`)", 'field IN (?)', ['one', 'two']],
-            ["field IN (`one`, `Array`)", 'field IN (?)', ['one', ['two']]],
-            ['field = NOW()', 'field = ?', new SqlFragment('NOW()')]
+            ['field IN (`one`, `two`)', 'field IN (?)', ['one', 'two']],
+            ['field IN (`one`, `Array`)', 'field IN (?)', ['one', ['two']]],
+            ['field = NOW()', 'field = ?', new SqlFragment('NOW()')],
         ];
     }
 
@@ -89,7 +89,7 @@ class QuoteHandlerTest extends TestCase
      */
     public function testColumnAs($expected, $ident, $alias, $auto)
     {
-        $result = (!is_null($auto)) ?
+        $result = ($auto !== null) ?
             $this->handler->columnAs($ident, $alias, $auto) :
             $this->handler->columnAs($ident, $alias);
         static::assertEquals($expected, $result);
@@ -98,11 +98,11 @@ class QuoteHandlerTest extends TestCase
     public function columnAsData()
     {
         return [
-            ["`col1`", 'col1', null, null],
-            ["`col1` AS `alias`", 'col1', 'alias', null],
-            ["`col1` AS `alias`", 'col1', 'alias', true],
-            ["`table1`.`col1`", ['table1', 'col1'], null, true],
-            ["`table1`.`col1`.`alias`", ['table1', 'col1', 'alias'], 'alias', true]
+            ['`col1`', 'col1', null, null],
+            ['`col1` AS `alias`', 'col1', 'alias', null],
+            ['`col1` AS `alias`', 'col1', 'alias', true],
+            ['`table1`.`col1`', ['table1', 'col1'], null, true],
+            ['`table1`.`col1`.`alias`', ['table1', 'col1', 'alias'], 'alias', true],
         ];
     }
 
@@ -115,7 +115,7 @@ class QuoteHandlerTest extends TestCase
      */
     public function testTableAs($expected, $ident, $alias, $auto)
     {
-        $result = (!is_null($alias)) ? (!is_null($auto)) ?
+        $result = ($alias !== null) ? ($auto !== null) ?
             $this->handler->tableAs($ident, $alias, $auto) :
             $this->handler->tableAs($ident, $alias) :
             $this->handler->tableAs($ident);
@@ -125,9 +125,9 @@ class QuoteHandlerTest extends TestCase
     public function tableAsData()
     {
         return [
-            ["`table1`", 'table1', null, null],
-            ["`table1` AS `alias`", 'table1', 'alias', null],
-            ["`table1` AS `alias`", 'table1', 'alias', true],
+            ['`table1`', 'table1', null, null],
+            ['`table1` AS `alias`', 'table1', 'alias', null],
+            ['`table1` AS `alias`', 'table1', 'alias', true],
         ];
     }
 
@@ -139,7 +139,7 @@ class QuoteHandlerTest extends TestCase
      */
     public function testIdentifier($expected, $ident, $auto)
     {
-        $result = (!is_null($auto)) ?
+        $result = ($auto !== null) ?
             $this->handler->identifier($ident, $auto) :
             $this->handler->identifier($ident);
         static::assertEquals($expected, $result);
@@ -148,11 +148,11 @@ class QuoteHandlerTest extends TestCase
     public function identifierData()
     {
         return [
-            ["`col1`", 'col1', null],
-            ["`col1`", 'col1', true],
-            ["NOW()", new SqlFragment('NOW()'), true],
-            ["`col1`.NOW()", ['col1', new SqlFragment('NOW()')], true],
-            ["`table1`.`*`", 'table1.*', true]
+            ['`col1`', 'col1', null],
+            ['`col1`', 'col1', true],
+            ['NOW()', new SqlFragment('NOW()'), true],
+            ['`col1`.NOW()', ['col1', new SqlFragment('NOW()')], true],
+            ['`table1`.`*`', 'table1.*', true],
         ];
     }
 }

--- a/tests/Adapter/QuoteHandlerTest.php
+++ b/tests/Adapter/QuoteHandlerTest.php
@@ -1,20 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\QuoteHandler;
 use Phlib\Db\SqlFragment;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class QuoteHandlerTest extends TestCase
 {
-    /**
-     * @var QuoteHandler|MockObject
-     */
-    private $handler;
+    private QuoteHandler $handler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->handler = new QuoteHandler(function ($value) {
             return "`{$value}`";
@@ -27,12 +25,12 @@ class QuoteHandlerTest extends TestCase
      * @param mixed $expected
      * @dataProvider valueDataProvider
      */
-    public function testValue($value, $expected)
+    public function testValue($value, $expected): void
     {
         static::assertEquals($expected, $this->handler->value($value));
     }
 
-    public function valueDataProvider()
+    public function valueDataProvider(): array
     {
         $toStringVal = 'foo';
         $object = new SqlFragment($toStringVal);
@@ -57,17 +55,15 @@ class QuoteHandlerTest extends TestCase
     }
 
     /**
-     * @param string $expected
-     * @param string $text
      * @param mixed $value
      * @dataProvider intoDataProvider
      */
-    public function testInto($expected, $text, $value)
+    public function testInto(string $expected, string $text, $value): void
     {
         static::assertEquals($expected, $this->handler->into($text, $value));
     }
 
-    public function intoDataProvider()
+    public function intoDataProvider(): array
     {
         return [
             ['field = `value`', 'field = ?', 'value'],
@@ -81,13 +77,10 @@ class QuoteHandlerTest extends TestCase
     }
 
     /**
-     * @param string $expected
-     * @param mixed $ident
-     * @param string $alias
-     * @param bool $auto
+     * @param string|string[] $ident
      * @dataProvider columnAsData
      */
-    public function testColumnAs($expected, $ident, $alias, $auto)
+    public function testColumnAs(string $expected, $ident, string $alias, ?bool $auto): void
     {
         $result = ($auto !== null) ?
             $this->handler->columnAs($ident, $alias, $auto) :
@@ -95,49 +88,42 @@ class QuoteHandlerTest extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function columnAsData()
+    public function columnAsData(): array
     {
         return [
-            ['`col1`', 'col1', null, null],
             ['`col1` AS `alias`', 'col1', 'alias', null],
             ['`col1` AS `alias`', 'col1', 'alias', true],
-            ['`table1`.`col1`', ['table1', 'col1'], null, true],
+            ['`table1`.`col1` AS `alias`', ['table1', 'col1'], 'alias', true],
             ['`table1`.`col1`.`alias`', ['table1', 'col1', 'alias'], 'alias', true],
         ];
     }
 
     /**
-     * @param string $expected
-     * @param string $ident
-     * @param string $alias
-     * @param bool $auto
+     * @param string|string[] $ident
      * @dataProvider tableAsData
      */
-    public function testTableAs($expected, $ident, $alias, $auto)
+    public function testTableAs(string $expected, $ident, string $alias, ?bool $auto): void
     {
-        $result = ($alias !== null) ? ($auto !== null) ?
+        $result = ($auto !== null) ?
             $this->handler->tableAs($ident, $alias, $auto) :
-            $this->handler->tableAs($ident, $alias) :
-            $this->handler->tableAs($ident);
+            $this->handler->tableAs($ident, $alias);
         static::assertEquals($expected, $result);
     }
 
-    public function tableAsData()
+    public function tableAsData(): array
     {
         return [
-            ['`table1`', 'table1', null, null],
             ['`table1` AS `alias`', 'table1', 'alias', null],
             ['`table1` AS `alias`', 'table1', 'alias', true],
+            ['`schema1`.`table1` AS `alias`', ['schema1', 'table1'], 'alias', true],
         ];
     }
 
     /**
-     * @param string $expected
-     * @param string $ident
-     * @param bool $auto
+     * @param string|string[] $ident
      * @dataProvider identifierData
      */
-    public function testIdentifier($expected, $ident, $auto)
+    public function testIdentifier(string $expected, $ident, ?bool $auto): void
     {
         $result = ($auto !== null) ?
             $this->handler->identifier($ident, $auto) :
@@ -145,7 +131,7 @@ class QuoteHandlerTest extends TestCase
         static::assertEquals($expected, $result);
     }
 
-    public function identifierData()
+    public function identifierData(): array
     {
         return [
             ['`col1`', 'col1', null],

--- a/tests/Adapter/QuoteHandlerTest.php
+++ b/tests/Adapter/QuoteHandlerTest.php
@@ -4,15 +4,16 @@ namespace Phlib\Db\Tests\Adapter;
 
 use Phlib\Db\Adapter\QuoteHandler;
 use Phlib\Db\SqlFragment;
+use PHPUnit\Framework\TestCase;
 
-class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
+class QuoteHandlerTest extends TestCase
 {
     /**
      * @var QuoteHandler|\PHPUnit_Framework_MockObject_MockObject
      */
     private $handler;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->handler = new QuoteHandler(function ($value) {
             return "`$value`";
@@ -27,7 +28,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testValue($value, $expected)
     {
-        $this->assertEquals($expected, $this->handler->value($value));
+        static::assertEquals($expected, $this->handler->value($value));
     }
 
     public function valueDataProvider()
@@ -62,7 +63,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInto($expected, $text, $value)
     {
-        $this->assertEquals($expected, $this->handler->into($text, $value));
+        static::assertEquals($expected, $this->handler->into($text, $value));
     }
 
     public function intoDataProvider()
@@ -90,7 +91,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
         $result = (!is_null($auto)) ?
             $this->handler->columnAs($ident, $alias, $auto) :
             $this->handler->columnAs($ident, $alias);
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
     }
 
     public function columnAsData()
@@ -117,7 +118,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
             $this->handler->tableAs($ident, $alias, $auto) :
             $this->handler->tableAs($ident, $alias) :
             $this->handler->tableAs($ident);
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
     }
 
     public function tableAsData()
@@ -140,7 +141,7 @@ class QuoteHandlerTest extends \PHPUnit_Framework_TestCase
         $result = (!is_null($auto)) ?
             $this->handler->identifier($ident, $auto) :
             $this->handler->identifier($ident);
-        $this->assertEquals($expected, $result);
+        static::assertEquals($expected, $result);
     }
 
     public function identifierData()

--- a/tests/Adapter/QuoteHandlerTest.php
+++ b/tests/Adapter/QuoteHandlerTest.php
@@ -27,7 +27,7 @@ class QuoteHandlerTest extends TestCase
      */
     public function testValue($value, $expected): void
     {
-        static::assertEquals($expected, $this->handler->value($value));
+        static::assertSame($expected, $this->handler->value($value));
     }
 
     public function valueDataProvider(): array
@@ -35,14 +35,14 @@ class QuoteHandlerTest extends TestCase
         $toStringVal = 'foo';
         $object = new SqlFragment($toStringVal);
         return [
-            [false, 0],
-            [true, 1],
-            [123, 123],
-            ['1', 1],
+            [false, '0'],
+            [true, '1'],
+            [123, '123'],
+            ['1', '1'],
             ['a1', '`a1`'],
             ['1a', '`1a`'],
-            [172.16, 172.16],
-            ['172.16', 172.16],
+            [172.16, '172.16'],
+            ['172.16', '172.16'],
             ['172.16.255.255', '`172.16.255.255`'],
             ['2017-03-18 00:00:00', '`2017-03-18 00:00:00`'],
             [null, 'NULL'],
@@ -60,7 +60,7 @@ class QuoteHandlerTest extends TestCase
      */
     public function testInto(string $expected, string $text, $value): void
     {
-        static::assertEquals($expected, $this->handler->into($text, $value));
+        static::assertSame($expected, $this->handler->into($text, $value));
     }
 
     public function intoDataProvider(): array
@@ -85,7 +85,7 @@ class QuoteHandlerTest extends TestCase
         $result = ($auto !== null) ?
             $this->handler->columnAs($ident, $alias, $auto) :
             $this->handler->columnAs($ident, $alias);
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function columnAsData(): array
@@ -107,7 +107,7 @@ class QuoteHandlerTest extends TestCase
         $result = ($auto !== null) ?
             $this->handler->tableAs($ident, $alias, $auto) :
             $this->handler->tableAs($ident, $alias);
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function tableAsData(): array
@@ -128,7 +128,7 @@ class QuoteHandlerTest extends TestCase
         $result = ($auto !== null) ?
             $this->handler->identifier($ident, $auto) :
             $this->handler->identifier($ident);
-        static::assertEquals($expected, $result);
+        static::assertSame($expected, $result);
     }
 
     public function identifierData(): array

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -6,6 +6,7 @@ use Phlib\Db\Adapter;
 use Phlib\Db\Exception\InvalidQueryException;
 use Phlib\Db\Exception\RuntimeException;
 use Phlib\Db\Exception\UnknownDatabaseException;
+use Phlib\Db\Tests\Exception\PDOExceptionStub;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -106,9 +107,9 @@ class AdapterTest extends TestCase
         $this->expectException(UnknownDatabaseException::class);
 
         $database = 'foobar';
-        $exception = new \PDOException(
+        $exception = new PDOExceptionStub(
             "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '{$database}'.",
-            42000
+            '42000'
         );
         $statement = $this->createMock(\PDOStatement::class);
         $statement->method('execute')
@@ -401,7 +402,7 @@ class AdapterTest extends TestCase
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
         $adapter->setConnectionFactory(function () {
-            $exception = new \PDOException('failed for some random reason', 1234);
+            $exception = new PDOExceptionStub('failed for some random reason', 1234);
             $statement = $this->createMock(\PDOStatement::class);
             $statement->method('execute')
                 ->willThrowException($exception);

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -31,14 +31,18 @@ class AdapterTest extends TestCase
     public function testQuoteHandlerIsSetupCorrectly()
     {
         $string = 'foo';
+        $expected = "'{$string}'";
         $this->pdo->expects(static::once())
             ->method('quote')
-            ->with($string);
+            ->with($string)
+            ->willReturn($expected);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
 
-        $adapter->quote()->value($string);
+        $actual = $adapter->quote()->value($string);
+
+        static::assertSame($expected, $actual);
     }
 
     public function testGetQuoteHandler()

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -54,7 +54,7 @@ class AdapterTest extends TestCase
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
 
-        static::assertEquals($this->pdo, $adapter->getConnection());
+        static::assertSame($this->pdo, $adapter->getConnection());
     }
 
     /**
@@ -123,7 +123,7 @@ class AdapterTest extends TestCase
         ];
 
         $adapter = new Adapter();
-        static::assertEquals($defaults, $adapter->getConfig());
+        static::assertSame($defaults, $adapter->getConfig());
     }
 
     public function testGetConfigMixed(): void
@@ -145,7 +145,7 @@ class AdapterTest extends TestCase
         ];
         $adapter = new Adapter($config);
 
-        static::assertEquals($expected, $adapter->getConfig());
+        static::assertSame($expected, $adapter->getConfig());
     }
 
     /**
@@ -163,7 +163,7 @@ class AdapterTest extends TestCase
         ];
         $adapter = new Adapter($config);
 
-        static::assertEquals($config, $adapter->getConfig());
+        static::assertSame($config, $adapter->getConfig());
     }
 
     /**
@@ -202,7 +202,7 @@ class AdapterTest extends TestCase
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $pdoStatement->method('fetchColumn')
-            ->willReturn(1);
+            ->willReturn('1');
         $this->pdo->method('prepare')
             ->willReturn($pdoStatement);
 
@@ -266,7 +266,7 @@ class AdapterTest extends TestCase
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        static::assertEquals($pdoStatement, $adapter->prepare($sql));
+        static::assertSame($pdoStatement, $adapter->prepare($sql));
     }
 
     public function testExecute(): void
@@ -336,7 +336,7 @@ class AdapterTest extends TestCase
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        static::assertEquals($pdoStatement, $adapter->query($sql));
+        static::assertSame($pdoStatement, $adapter->query($sql));
     }
 
     public function testQueryWithBind(): void
@@ -354,7 +354,7 @@ class AdapterTest extends TestCase
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        static::assertEquals($pdoStatement, $adapter->query($sql, $bind));
+        static::assertSame($pdoStatement, $adapter->query($sql, $bind));
     }
 
     public function testQueryWithInvalidSql(): void

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -3,8 +3,9 @@
 namespace Phlib\Db\Tests;
 
 use Phlib\Db\Adapter;
+use PHPUnit\Framework\TestCase;
 
-class AdapterTest extends \PHPUnit_Framework_TestCase
+class AdapterTest extends TestCase
 {
     /**
      * @var \PDO|\PHPUnit_Framework_MockObject_MockObject
@@ -17,22 +18,16 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
      */
     private $qc = '`';
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->pdo = $this->createMock(\PDO::class);
     }
 
-    public function tearDown()
-    {
-        $this->pdo = null;
-        parent::tearDown();
-    }
-
     public function testQuoteHandlerIsSetupCorrectly()
     {
         $string = 'foo';
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('quote')
             ->with($string);
 
@@ -46,7 +41,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertInstanceOf(Adapter\QuoteHandler::class, $adapter->quote());
+        static::assertInstanceOf(Adapter\QuoteHandler::class, $adapter->quote());
     }
 
     /**
@@ -57,7 +52,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
 
-        $this->assertEquals($this->pdo, $adapter->getConnection());
+        static::assertEquals($this->pdo, $adapter->getConnection());
     }
 
     /**
@@ -71,9 +66,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
-        $adapter->expects($this->once())
+        $adapter->expects(static::once())
             ->method('query')
-            ->with($this->equalTo("USE `$dbname`"));
+            ->with("USE `$dbname`");
 
         $adapter->setConnection($this->pdo);
         $adapter->setDatabase($dbname);
@@ -94,8 +89,8 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         $config = $adapter->getConfig();
 
-        $this->assertArrayHasKey('dbname', $config);
-        $this->assertSame($dbname, $config['dbname']);
+        static::assertArrayHasKey('dbname', $config);
+        static::assertSame($dbname, $config['dbname']);
     }
 
     /**
@@ -109,12 +104,10 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
             42000
         );
         $statement = $this->createMock(\PDOStatement::class);
-        $statement->expects($this->any())
-            ->method('execute')
-            ->will($this->throwException($exception));
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($statement));
+        $statement->method('execute')
+            ->willThrowException($exception);
+        $this->pdo->method('prepare')
+            ->willReturn($statement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
@@ -129,7 +122,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         ];
 
         $adapter = new Adapter();
-        $this->assertEquals($defaults, $adapter->getConfig());
+        static::assertEquals($defaults, $adapter->getConfig());
     }
 
     public function testGetConfigMixed()
@@ -151,7 +144,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         ];
         $adapter = new Adapter($config);
 
-        $this->assertEquals($expected, $adapter->getConfig());
+        static::assertEquals($expected, $adapter->getConfig());
     }
 
     /**
@@ -169,7 +162,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         ];
         $adapter = new Adapter($config);
 
-        $this->assertEquals($config, $adapter->getConfig());
+        static::assertEquals($config, $adapter->getConfig());
     }
 
     /**
@@ -180,12 +173,11 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     public function testSettingAdapterOptionsWithConnection($option, $value)
     {
         $statement = $this->createMock(\PDOStatement::class);
-        $statement->expects($this->once())
+        $statement->expects(static::once())
             ->method('execute')
-            ->with($this->contains($value));
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($statement));
+            ->with(static::contains($value));
+        $this->pdo->method('prepare')
+            ->willReturn($statement);
 
         $method  = 'set' . ucfirst($option);
         $adapter = new Adapter();
@@ -209,17 +201,14 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     public function testSuccessfulPing()
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement
-            ->expects($this->any())
-            ->method('fetchColumn')
-            ->will($this->returnValue(1));
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($pdoStatement));
+        $pdoStatement->method('fetchColumn')
+            ->willReturn(1);
+        $this->pdo->method('prepare')
+            ->willReturn($pdoStatement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertTrue($adapter->ping());
+        static::assertTrue($adapter->ping());
     }
 
     /**
@@ -227,20 +216,19 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailedPing()
     {
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->throwException(new \Exception));
+        $this->pdo->method('prepare')
+            ->willThrowException(new \Exception);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertFalse($adapter->ping());
+        static::assertFalse($adapter->ping());
     }
 
     public function testLastInsertIdNoTableName()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('lastInsertId')
-            ->with($this->equalTo(null));
+            ->with(null);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
@@ -250,9 +238,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     public function testLastInsertIdWithTableName()
     {
         $tableName = 'table';
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('lastInsertId')
-            ->with($this->equalTo($tableName));
+            ->with($tableName);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
@@ -263,14 +251,14 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
         $sql = 'SELECT * FROM table';
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('prepare')
-            ->with($this->equalTo($sql))
-            ->will($this->returnValue($pdoStatement));
+            ->with($sql)
+            ->willReturn($pdoStatement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertEquals($pdoStatement, $adapter->prepare($sql));
+        static::assertEquals($pdoStatement, $adapter->prepare($sql));
     }
 
     public function testExecute()
@@ -279,7 +267,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('rowCount');
 
         // Exec should call query with the SQL
@@ -287,10 +275,10 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
-        $adapter->expects($this->once())
+        $adapter->expects(static::once())
             ->method('query')
             ->with($sql)
-            ->will($this->returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
         $adapter->setConnection($this->pdo);
         $adapter->execute($sql);
     }
@@ -302,7 +290,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
         // Returned stmt will have rowCount called
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('rowCount');
 
         // Exec should call query with the SQL
@@ -310,10 +298,10 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
-        $adapter->expects($this->once())
+        $adapter->expects(static::once())
             ->method('query')
             ->with($sql, $bind)
-            ->will($this->returnValue($pdoStatement));
+            ->willReturn($pdoStatement);
         $adapter->setConnection($this->pdo);
         $adapter->execute($sql, $bind);
     }
@@ -322,17 +310,17 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         $sql = 'SELECT * FROM table';
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('execute')
-            ->with($this->equalTo([]));
-        $this->pdo->expects($this->once())
+            ->with([]);
+        $this->pdo->expects(static::once())
             ->method('prepare')
-            ->with($this->equalTo($sql))
-            ->will($this->returnValue($pdoStatement));
+            ->with($sql)
+            ->willReturn($pdoStatement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertEquals($pdoStatement, $adapter->query($sql));
+        static::assertEquals($pdoStatement, $adapter->query($sql));
     }
 
     public function testQueryWithBind()
@@ -340,17 +328,17 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         $sql = 'SELECT * FROM table WHERE col1 = ?';
         $bind = ['col1' => 'v1'];
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $pdoStatement->expects($this->once())
+        $pdoStatement->expects(static::once())
             ->method('execute')
-            ->with($this->equalTo($bind));
-        $this->pdo->expects($this->once())
+            ->with($bind);
+        $this->pdo->expects(static::once())
             ->method('prepare')
-            ->with($this->equalTo($sql))
-            ->will($this->returnValue($pdoStatement));
+            ->with($sql)
+            ->willReturn($pdoStatement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertEquals($pdoStatement, $adapter->query($sql, $bind));
+        static::assertEquals($pdoStatement, $adapter->query($sql, $bind));
     }
 
     /**
@@ -360,12 +348,10 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         $exception = new \PDOException('You have an error in your SQL syntax');
         $statement = $this->createMock(\PDOStatement::class);
-        $statement->expects($this->any())
-            ->method('execute')
-            ->will($this->throwException($exception));
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($statement));
+        $statement->method('execute')
+            ->willThrowException($exception);
+        $this->pdo->method('prepare')
+            ->willReturn($statement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
@@ -376,23 +362,20 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         $exception = new \PDOException('MySQL server has gone away');
         $statement = $this->createMock(\PDOStatement::class);
-        $statement->expects($this->any())
-            ->method('execute')
-            ->will($this->throwException($exception));
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($statement));
+        $statement->method('execute')
+            ->willThrowException($exception);
+        $this->pdo->method('prepare')
+            ->willReturn($statement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
         $adapter->setConnectionFactory(function () {
             $statement = $this->createMock(\PDOStatement::class);
-            $statement->expects($this->once())
+            $statement->expects(static::once())
                 ->method('execute');
             $pdo = $this->createMock(\PDO::class);
-            $pdo->expects($this->any())
-                ->method('prepare')
-                ->will($this->returnValue($statement));
+            $pdo->method('prepare')
+                ->willReturn($statement);
             return $pdo;
         });
         $adapter->query('SELECT * FROM foo');
@@ -405,25 +388,21 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     {
         $exception = new \PDOException('MySQL server has gone away');
         $statement = $this->createMock(\PDOStatement::class);
-        $statement->expects($this->any())
-            ->method('execute')
-            ->will($this->throwException($exception));
-        $this->pdo->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($statement));
+        $statement->method('execute')
+            ->willThrowException($exception);
+        $this->pdo->method('prepare')
+            ->willReturn($statement);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
         $adapter->setConnectionFactory(function () {
             $exception = new \PDOException('failed for some random reason', 1234);
             $statement = $this->createMock(\PDOStatement::class);
-            $statement->expects($this->any())
-                ->method('execute')
-                ->will($this->throwException($exception));
+            $statement->method('execute')
+                ->willThrowException($exception);
             $pdo = $this->createMock(\PDO::class);
-            $pdo->expects($this->any())
-                ->method('prepare')
-                ->will($this->returnValue($statement));
+            $pdo->method('prepare')
+                ->willReturn($statement);
             return $pdo;
         });
         $adapter->query('SELECT * FROM foo');
@@ -431,12 +410,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetBufferedConnectionToUnbuffered()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('setAttribute')
-            ->with(
-                $this->equalTo(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY),
-                $this->equalTo(false)
-            )
+            ->with(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false)
             ->willReturn(true);
 
         $adapter = new Adapter();
@@ -446,12 +422,9 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testSetUnbufferedConnectionToBuffered()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('setAttribute')
-            ->with(
-                $this->equalTo(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY),
-                $this->equalTo(true)
-            )
+            ->with(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true)
             ->willReturn(true);
 
         $adapter = new Adapter();
@@ -461,14 +434,14 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testIsBufferedConnection()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('getAttribute')
-            ->with($this->equalTo(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY))
-            ->will($this->returnValue(true));
+            ->with(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY)
+            ->willReturn(true);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $this->assertTrue($adapter->isBuffered());
+        static::assertTrue($adapter->isBuffered());
     }
 
     public function testCloning()
@@ -480,12 +453,12 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
         });
 
         $newAdapter = clone $adapter;
-        $this->assertNotSame($adapter, $newAdapter);
+        static::assertNotSame($adapter, $newAdapter);
     }
 
     public function testBeginTransaction()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('beginTransaction');
 
         $adapter = new Adapter();
@@ -496,15 +469,14 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     public function testBeginTransactionWhenServerHasGoneAway()
     {
         $exception = new \PDOException('MySQL server has gone away');
-        $this->pdo->expects($this->any())
-            ->method('beginTransaction')
-            ->will($this->throwException($exception));
+        $this->pdo->method('beginTransaction')
+            ->willThrowException($exception);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
         $adapter->setConnectionFactory(function () {
             $pdo = $this->createMock(\PDO::class);
-            $pdo->expects($this->once())
+            $pdo->expects(static::once())
                 ->method('beginTransaction');
             return $pdo;
         });
@@ -517,18 +489,16 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
     public function testBeginTransactionWhenServerHasGoneAwayAndThenFails()
     {
         $exception = new \PDOException('MySQL server has gone away');
-        $this->pdo->expects($this->any())
-            ->method('beginTransaction')
-            ->will($this->throwException($exception));
+        $this->pdo->method('beginTransaction')
+            ->willThrowException($exception);
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
         $adapter->setConnectionFactory(function () {
             $exception = new \PDOException('something else bad happened');
             $pdo = $this->createMock(\PDO::class);
-            $pdo->expects($this->any())
-                ->method('beginTransaction')
-                ->will($this->throwException($exception));
+            $pdo->method('beginTransaction')
+                ->willThrowException($exception);
             return $pdo;
         });
         $adapter->beginTransaction();
@@ -536,7 +506,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testCommit()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('commit');
 
         $adapter = new Adapter();
@@ -546,7 +516,7 @@ class AdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testRollback()
     {
-        $this->pdo->expects($this->once())
+        $this->pdo->expects(static::once())
             ->method('rollback');
 
         $adapter = new Adapter();

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -175,7 +175,7 @@ class AdapterTest extends TestCase
         $statement = $this->createMock(\PDOStatement::class);
         $statement->expects(static::once())
             ->method('execute')
-            ->with(static::contains($value));
+            ->with(static::containsIdentical($value));
         $this->pdo->method('prepare')
             ->willReturn($statement);
 

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -3,12 +3,16 @@
 namespace Phlib\Db\Tests;
 
 use Phlib\Db\Adapter;
+use Phlib\Db\Exception\InvalidQueryException;
+use Phlib\Db\Exception\RuntimeException;
+use Phlib\Db\Exception\UnknownDatabaseException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AdapterTest extends TestCase
 {
     /**
-     * @var \PDO|\PHPUnit_Framework_MockObject_MockObject
+     * @var \PDO|MockObject
      */
     private $pdo;
 
@@ -62,7 +66,7 @@ class AdapterTest extends TestCase
     {
         $dbname = 'MyDbName';
 
-        /** @var Adapter|\PHPUnit_Framework_MockObject_MockObject $adapter */
+        /** @var Adapter|MockObject $adapter */
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
@@ -80,7 +84,7 @@ class AdapterTest extends TestCase
     public function testSetDatabaseSetsConfig()
     {
         $dbname = 'MyDbName';
-        /** @var Adapter|\PHPUnit_Framework_MockObject_MockObject $adapter */
+        /** @var Adapter|MockObject $adapter */
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
@@ -93,11 +97,10 @@ class AdapterTest extends TestCase
         static::assertSame($dbname, $config['dbname']);
     }
 
-    /**
-     * @expectedException \Phlib\Db\Exception\UnknownDatabaseException
-     */
     public function testSetDatabaseWhenItsUnknown()
     {
+        $this->expectException(UnknownDatabaseException::class);
+
         $database  = 'foobar';
         $exception = new \PDOException(
             "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '$database'.",
@@ -271,7 +274,7 @@ class AdapterTest extends TestCase
             ->method('rowCount');
 
         // Exec should call query with the SQL
-        /** @var Adapter|\PHPUnit_Framework_MockObject_MockObject $adapter */
+        /** @var Adapter|MockObject $adapter */
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
@@ -294,7 +297,7 @@ class AdapterTest extends TestCase
             ->method('rowCount');
 
         // Exec should call query with the SQL
-        /** @var Adapter|\PHPUnit_Framework_MockObject_MockObject $adapter */
+        /** @var Adapter|MockObject $adapter */
         $adapter = $this->getMockBuilder(Adapter::class)
             ->setMethods(['query'])
             ->getMock();
@@ -341,11 +344,10 @@ class AdapterTest extends TestCase
         static::assertEquals($pdoStatement, $adapter->query($sql, $bind));
     }
 
-    /**
-     * @expectedException \Phlib\Db\Exception\InvalidQueryException
-     */
     public function testQueryWithInvalidSql()
     {
+        $this->expectException(InvalidQueryException::class);
+
         $exception = new \PDOException('You have an error in your SQL syntax');
         $statement = $this->createMock(\PDOStatement::class);
         $statement->method('execute')
@@ -381,11 +383,10 @@ class AdapterTest extends TestCase
         $adapter->query('SELECT * FROM foo');
     }
 
-    /**
-     * @expectedException \Phlib\Db\Exception\RuntimeException
-     */
     public function testQueryFailsAfterSuccessfulReconnect()
     {
+        $this->expectException(RuntimeException::class);
+
         $exception = new \PDOException('MySQL server has gone away');
         $statement = $this->createMock(\PDOStatement::class);
         $statement->method('execute')
@@ -483,11 +484,10 @@ class AdapterTest extends TestCase
         $adapter->beginTransaction();
     }
 
-    /**
-     * @expectedException \Phlib\Db\Exception\RuntimeException
-     */
     public function testBeginTransactionWhenServerHasGoneAwayAndThenFails()
     {
+        $this->expectException(RuntimeException::class);
+
         $exception = new \PDOException('MySQL server has gone away');
         $this->pdo->method('beginTransaction')
             ->willThrowException($exception);

--- a/tests/AdapterTest.php
+++ b/tests/AdapterTest.php
@@ -72,7 +72,7 @@ class AdapterTest extends TestCase
             ->getMock();
         $adapter->expects(static::once())
             ->method('query')
-            ->with("USE `$dbname`");
+            ->with("USE `{$dbname}`");
 
         $adapter->setConnection($this->pdo);
         $adapter->setDatabase($dbname);
@@ -101,9 +101,9 @@ class AdapterTest extends TestCase
     {
         $this->expectException(UnknownDatabaseException::class);
 
-        $database  = 'foobar';
+        $database = 'foobar';
         $exception = new \PDOException(
-            "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '$database'.",
+            "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '{$database}'.",
             42000
         );
         $statement = $this->createMock(\PDOStatement::class);
@@ -120,8 +120,8 @@ class AdapterTest extends TestCase
     public function testGetConfigDefaults()
     {
         $defaults = [
-            'charset'  => 'utf8mb4',
-            'timezone' => '+0:00'
+            'charset' => 'utf8mb4',
+            'timezone' => '+0:00',
         ];
 
         $adapter = new Adapter();
@@ -131,19 +131,19 @@ class AdapterTest extends TestCase
     public function testGetConfigMixed()
     {
         $expected = [
-            'host'     => 'localhost',
+            'host' => 'localhost',
             'username' => 'username',
             'password' => 'password',
-            'port'     => '3306',
-            'charset'  => 'utf8mb4',
-            'timezone' => '+0:00'
+            'port' => '3306',
+            'charset' => 'utf8mb4',
+            'timezone' => '+0:00',
         ];
 
         $config = [
-            'host'     => 'localhost',
+            'host' => 'localhost',
             'username' => 'username',
             'password' => 'password',
-            'port'     => '3306'
+            'port' => '3306',
         ];
         $adapter = new Adapter($config);
 
@@ -156,12 +156,12 @@ class AdapterTest extends TestCase
     public function testGetConfigOverrides()
     {
         $config = [
-            'host'     => 'localhost',
+            'host' => 'localhost',
             'username' => 'username',
             'password' => 'password',
-            'port'     => '3306',
-            'charset'  => 'iso-8859-1',
-            'timezone' => '+1:00'
+            'port' => '3306',
+            'charset' => 'iso-8859-1',
+            'timezone' => '+1:00',
         ];
         $adapter = new Adapter($config);
 
@@ -182,10 +182,10 @@ class AdapterTest extends TestCase
         $this->pdo->method('prepare')
             ->willReturn($statement);
 
-        $method  = 'set' . ucfirst($option);
+        $method = 'set' . ucfirst($option);
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);
-        $adapter->$method($value);
+        $adapter->{$method}($value);
     }
 
     public function settingAdapterOptionsDataProvider()
@@ -194,7 +194,7 @@ class AdapterTest extends TestCase
             ['charset', 'iso-8859-1'],
             ['charset', 'utf8'],
             ['timezone', '+05:00'],
-            ['timezone', '+03:00']
+            ['timezone', '+03:00'],
         ];
     }
 
@@ -220,7 +220,7 @@ class AdapterTest extends TestCase
     public function testFailedPing()
     {
         $this->pdo->method('prepare')
-            ->willThrowException(new \Exception);
+            ->willThrowException(new \Exception());
 
         $adapter = new Adapter();
         $adapter->setConnection($this->pdo);

--- a/tests/Exception/InvalidQueryExceptionTest.php
+++ b/tests/Exception/InvalidQueryExceptionTest.php
@@ -16,8 +16,8 @@ class InvalidQueryExceptionTest extends TestCase
     public function testConstructorUsesPreviousException()
     {
         $code = 42000;
-        $message = "SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; " .
-            "check the manual that corresponds to your MySQL server version for the right syntax to use near " .
+        $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
+            'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'FRM foo' at line 1";
         $pdoException = new \PDOException($message, $code);
         $exception = new InvalidQueryException('SELECT * FRM foo', [], $pdoException);
@@ -41,8 +41,8 @@ class InvalidQueryExceptionTest extends TestCase
     public function testSuccessfullyDetectsInvalidSyntaxException()
     {
         $code = 42000;
-        $message = "SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; " .
-            "check the manual that corresponds to your MySQL server version for the right syntax to use near " .
+        $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
+            'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'FRM foo' at line 1";
         $pdoException = new \PDOException($message, $code);
         static::assertTrue(InvalidQueryException::isInvalidSyntax($pdoException));
@@ -51,7 +51,7 @@ class InvalidQueryExceptionTest extends TestCase
     public function testDetectsNonSyntaxException()
     {
         $code = 2002;
-        $message = "SQLSTATE[HY000] [2002] Connection reset by peer";
+        $message = 'SQLSTATE[HY000] [2002] Connection reset by peer';
         $pdoException = new \PDOException($message, $code);
         static::assertFalse(InvalidQueryException::isInvalidSyntax($pdoException));
     }

--- a/tests/Exception/InvalidQueryExceptionTest.php
+++ b/tests/Exception/InvalidQueryExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Exception;
 
 use Phlib\Db\Exception\InvalidQueryException;
@@ -7,13 +9,13 @@ use PHPUnit\Framework\TestCase;
 
 class InvalidQueryExceptionTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $exception = new InvalidQueryException('SLECT * FRM foo', []);
         static::assertNotEmpty($exception->getMessage());
     }
 
-    public function testConstructorUsesPreviousException()
+    public function testConstructorUsesPreviousException(): void
     {
         $code = '42000';
         $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
@@ -24,21 +26,21 @@ class InvalidQueryExceptionTest extends TestCase
         static::assertStringStartsWith($message, $exception->getMessage());
     }
 
-    public function testGetQuery()
+    public function testGetQuery(): void
     {
         $query = 'SELECT * FRM foo';
         $exception = new InvalidQueryException($query, []);
         static::assertEquals($query, $exception->getQuery());
     }
 
-    public function testGetBindData()
+    public function testGetBindData(): void
     {
         $bind = ['foo', 'bar'];
         $exception = new InvalidQueryException('', $bind);
         static::assertEquals($bind, $exception->getBindData());
     }
 
-    public function testSuccessfullyDetectsInvalidSyntaxException()
+    public function testSuccessfullyDetectsInvalidSyntaxException(): void
     {
         $code = '42000';
         $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
@@ -48,7 +50,7 @@ class InvalidQueryExceptionTest extends TestCase
         static::assertTrue(InvalidQueryException::isInvalidSyntax($pdoException));
     }
 
-    public function testDetectsNonSyntaxException()
+    public function testDetectsNonSyntaxException(): void
     {
         $code = 2002;
         $message = 'SQLSTATE[HY000] [2002] Connection reset by peer';

--- a/tests/Exception/InvalidQueryExceptionTest.php
+++ b/tests/Exception/InvalidQueryExceptionTest.php
@@ -30,14 +30,14 @@ class InvalidQueryExceptionTest extends TestCase
     {
         $query = 'SELECT * FRM foo';
         $exception = new InvalidQueryException($query, []);
-        static::assertEquals($query, $exception->getQuery());
+        static::assertSame($query, $exception->getQuery());
     }
 
     public function testGetBindData(): void
     {
         $bind = ['foo', 'bar'];
         $exception = new InvalidQueryException('', $bind);
-        static::assertEquals($bind, $exception->getBindData());
+        static::assertSame($bind, $exception->getBindData());
     }
 
     public function testSuccessfullyDetectsInvalidSyntaxException(): void

--- a/tests/Exception/InvalidQueryExceptionTest.php
+++ b/tests/Exception/InvalidQueryExceptionTest.php
@@ -3,13 +3,14 @@
 namespace Phlib\Db\Tests\Exception;
 
 use Phlib\Db\Exception\InvalidQueryException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidQueryExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidQueryExceptionTest extends TestCase
 {
     public function testConstructor()
     {
         $exception = new InvalidQueryException('SLECT * FRM foo', []);
-        $this->assertNotEmpty($exception->getMessage());
+        static::assertNotEmpty($exception->getMessage());
     }
 
     public function testConstructorUsesPreviousException()
@@ -20,21 +21,21 @@ class InvalidQueryExceptionTest extends \PHPUnit_Framework_TestCase
             "'FRM foo' at line 1";
         $pdoException = new \PDOException($message, $code);
         $exception = new InvalidQueryException('SELECT * FRM foo', [], $pdoException);
-        $this->assertStringStartsWith($message, $exception->getMessage());
+        static::assertStringStartsWith($message, $exception->getMessage());
     }
 
     public function testGetQuery()
     {
         $query = 'SELECT * FRM foo';
         $exception = new InvalidQueryException($query, []);
-        $this->assertEquals($query, $exception->getQuery());
+        static::assertEquals($query, $exception->getQuery());
     }
 
     public function testGetBindData()
     {
         $bind = ['foo', 'bar'];
         $exception = new InvalidQueryException('', $bind);
-        $this->assertEquals($bind, $exception->getBindData());
+        static::assertEquals($bind, $exception->getBindData());
     }
 
     public function testSuccessfullyDetectsInvalidSyntaxException()
@@ -44,7 +45,7 @@ class InvalidQueryExceptionTest extends \PHPUnit_Framework_TestCase
             "check the manual that corresponds to your MySQL server version for the right syntax to use near " .
             "'FRM foo' at line 1";
         $pdoException = new \PDOException($message, $code);
-        $this->assertTrue(InvalidQueryException::isInvalidSyntax($pdoException));
+        static::assertTrue(InvalidQueryException::isInvalidSyntax($pdoException));
     }
 
     public function testDetectsNonSyntaxException()
@@ -52,6 +53,6 @@ class InvalidQueryExceptionTest extends \PHPUnit_Framework_TestCase
         $code = 2002;
         $message = "SQLSTATE[HY000] [2002] Connection reset by peer";
         $pdoException = new \PDOException($message, $code);
-        $this->assertFalse(InvalidQueryException::isInvalidSyntax($pdoException));
+        static::assertFalse(InvalidQueryException::isInvalidSyntax($pdoException));
     }
 }

--- a/tests/Exception/InvalidQueryExceptionTest.php
+++ b/tests/Exception/InvalidQueryExceptionTest.php
@@ -15,11 +15,11 @@ class InvalidQueryExceptionTest extends TestCase
 
     public function testConstructorUsesPreviousException()
     {
-        $code = 42000;
+        $code = '42000';
         $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
             'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'FRM foo' at line 1";
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         $exception = new InvalidQueryException('SELECT * FRM foo', [], $pdoException);
         static::assertStringStartsWith($message, $exception->getMessage());
     }
@@ -40,11 +40,11 @@ class InvalidQueryExceptionTest extends TestCase
 
     public function testSuccessfullyDetectsInvalidSyntaxException()
     {
-        $code = 42000;
+        $code = '42000';
         $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
             'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'FRM foo' at line 1";
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         static::assertTrue(InvalidQueryException::isInvalidSyntax($pdoException));
     }
 
@@ -52,7 +52,7 @@ class InvalidQueryExceptionTest extends TestCase
     {
         $code = 2002;
         $message = 'SQLSTATE[HY000] [2002] Connection reset by peer';
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         static::assertFalse(InvalidQueryException::isInvalidSyntax($pdoException));
     }
 }

--- a/tests/Exception/PDOExceptionStub.php
+++ b/tests/Exception/PDOExceptionStub.php
@@ -6,8 +6,8 @@ class PDOExceptionStub extends \PDOException
 {
     public function __construct($message = '', $code = 0, \Exception $previous = null)
     {
-        $this->message  = $message;
-        $this->code     = $code;
+        $this->message = $message;
+        $this->code = $code;
         $this->previous = $previous;
     }
 }

--- a/tests/Exception/PDOExceptionStub.php
+++ b/tests/Exception/PDOExceptionStub.php
@@ -1,13 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Exception;
 
 class PDOExceptionStub extends \PDOException
 {
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    /**
+     * @param int|string $code
+     */
+    public function __construct(string $message, $code, \Exception $previous = null)
     {
-        $this->message = $message;
+        parent::__construct($message, 0, $previous);
+
+        /*
+         * \PDOException overrides \Exception to define $code as a string
+         * so that it can support the 5-char error codes defined in the ANSI SQL standard.
+         * In reality, it returns a mixture of int and string, for example:
+         * - (int)1044 for access denied
+         * - (int)1049 for unknown database
+         * - (string)42S02 for unknown table
+         * - (string)42000 for syntax error, even though this could be int
+         */
+        if (is_int($code) && $code > 9999) {
+            // Codes with 5+ chars are always strings
+            $code = (string)$code;
+        } elseif (is_string($code) && strlen($code) < 5 && $code === (string)(int)$code) {
+            // Use int for all-numeric codes that are shorter than 5 chars
+            $code = (int)$code;
+        }
         $this->code = $code;
-        $this->previous = $previous;
     }
 }

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -24,7 +24,7 @@ class RuntimeExceptionTest extends TestCase
     public function testIgnoresOtherPdoExceptions()
     {
         $code = 2002;
-        $message = "SQLSTATE[HY000] [2002] Connection reset by peer";
+        $message = 'SQLSTATE[HY000] [2002] Connection reset by peer';
         $pdoException = new \PDOException($message, $code);
         static::assertFalse(RuntimeException::hasServerGoneAway($pdoException));
     }

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -17,7 +17,7 @@ class RuntimeExceptionTest extends TestCase
     {
         $code = 2006;
         $message = 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away';
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         static::assertTrue(RuntimeException::hasServerGoneAway($pdoException));
     }
 
@@ -25,7 +25,7 @@ class RuntimeExceptionTest extends TestCase
     {
         $code = 2002;
         $message = 'SQLSTATE[HY000] [2002] Connection reset by peer';
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         static::assertFalse(RuntimeException::hasServerGoneAway($pdoException));
     }
 

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -3,13 +3,14 @@
 namespace Phlib\Db\Tests\Exception;
 
 use Phlib\Db\Exception\RuntimeException;
+use PHPUnit\Framework\TestCase;
 
-class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
+class RuntimeExceptionTest extends TestCase
 {
     public function testCreate()
     {
         $pdoException = new \PDOException();
-        $this->assertInstanceOf(RuntimeException::class, RuntimeException::createFromException($pdoException));
+        static::assertInstanceOf(RuntimeException::class, RuntimeException::createFromException($pdoException));
     }
 
     public function testSuccessfullyDetectServerHasGoneAway()
@@ -17,7 +18,7 @@ class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
         $code = 2006;
         $message = 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away';
         $pdoException = new \PDOException($message, $code);
-        $this->assertTrue(RuntimeException::hasServerGoneAway($pdoException));
+        static::assertTrue(RuntimeException::hasServerGoneAway($pdoException));
     }
 
     public function testIgnoresOtherPdoExceptions()
@@ -25,7 +26,7 @@ class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
         $code = 2002;
         $message = "SQLSTATE[HY000] [2002] Connection reset by peer";
         $pdoException = new \PDOException($message, $code);
-        $this->assertFalse(RuntimeException::hasServerGoneAway($pdoException));
+        static::assertFalse(RuntimeException::hasServerGoneAway($pdoException));
     }
 
     /**
@@ -34,7 +35,7 @@ class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
     public function testCreateWithWeirdPdoExceptionCodeStringType()
     {
         $pdoException = new PDOExceptionStub('Unknown or incorrect', 'HY000');
-        $this->assertInstanceOf(RuntimeException::class, RuntimeException::createFromException($pdoException));
+        static::assertInstanceOf(RuntimeException::class, RuntimeException::createFromException($pdoException));
     }
 
     public function testCreateWithWeirdPdoExceptionCodeDocumentGetCodeReturnValue()
@@ -42,6 +43,6 @@ class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
         $code = 'HY000';
         $pdoException = new PDOExceptionStub('Unknow or incorrect', $code);
         $newException = RuntimeException::createFromException($pdoException);
-        $this->assertEquals($code, $newException->getCode());
+        static::assertEquals($code, $newException->getCode());
     }
 }

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Exception;
 
 use Phlib\Db\Exception\RuntimeException;
@@ -7,13 +9,13 @@ use PHPUnit\Framework\TestCase;
 
 class RuntimeExceptionTest extends TestCase
 {
-    public function testCreate()
+    public function testCreate(): void
     {
         $pdoException = new \PDOException();
         static::assertInstanceOf(RuntimeException::class, RuntimeException::createFromException($pdoException));
     }
 
-    public function testSuccessfullyDetectServerHasGoneAway()
+    public function testSuccessfullyDetectServerHasGoneAway(): void
     {
         $code = 2006;
         $message = 'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away';
@@ -21,7 +23,7 @@ class RuntimeExceptionTest extends TestCase
         static::assertTrue(RuntimeException::hasServerGoneAway($pdoException));
     }
 
-    public function testIgnoresOtherPdoExceptions()
+    public function testIgnoresOtherPdoExceptions(): void
     {
         $code = 2002;
         $message = 'SQLSTATE[HY000] [2002] Connection reset by peer';
@@ -32,13 +34,13 @@ class RuntimeExceptionTest extends TestCase
     /**
      * @link http://php.net/manual/en/class.pdoexception.php see property $code type
      */
-    public function testCreateWithWeirdPdoExceptionCodeStringType()
+    public function testCreateWithWeirdPdoExceptionCodeStringType(): void
     {
         $pdoException = new PDOExceptionStub('Unknown or incorrect', 'HY000');
         static::assertInstanceOf(RuntimeException::class, RuntimeException::createFromException($pdoException));
     }
 
-    public function testCreateWithWeirdPdoExceptionCodeDocumentGetCodeReturnValue()
+    public function testCreateWithWeirdPdoExceptionCodeDocumentGetCodeReturnValue(): void
     {
         $code = 'HY000';
         $pdoException = new PDOExceptionStub('Unknow or incorrect', $code);

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -45,6 +45,6 @@ class RuntimeExceptionTest extends TestCase
         $code = 'HY000';
         $pdoException = new PDOExceptionStub('Unknow or incorrect', $code);
         $newException = RuntimeException::createFromException($pdoException);
-        static::assertEquals($code, $newException->getCode());
+        static::assertSame($code, $newException->getCode());
     }
 }

--- a/tests/Exception/UnknownDatabaseExceptionTest.php
+++ b/tests/Exception/UnknownDatabaseExceptionTest.php
@@ -3,33 +3,34 @@
 namespace Phlib\Db\Tests\Exception;
 
 use Phlib\Db\Exception\UnknownDatabaseException;
+use PHPUnit\Framework\TestCase;
 
-class UnknownDatabaseExceptionTest extends \PHPUnit_Framework_TestCase
+class UnknownDatabaseExceptionTest extends TestCase
 {
     public function testCreateReturnsException()
     {
         $exception = UnknownDatabaseException::createFromUnknownDatabase('foo', new \PDOException());
-        $this->assertInstanceOf(UnknownDatabaseException::class, $exception);
+        static::assertInstanceOf(UnknownDatabaseException::class, $exception);
     }
 
     public function testGetDatabaseName()
     {
         $name = 'foo';
         $exception = new UnknownDatabaseException($name, 'message');
-        $this->assertEquals($name, $exception->getDatabaseName());
+        static::assertEquals($name, $exception->getDatabaseName());
     }
 
     public function testGetDatabaseNameWhenCreated()
     {
         $name = 'foo';
         $exception = UnknownDatabaseException::createFromUnknownDatabase($name, new \PDOException());
-        $this->assertEquals($name, $exception->getDatabaseName());
+        static::assertEquals($name, $exception->getDatabaseName());
     }
 
     public function testCorrectlyEvaluatesPdoExceptionOnPdoConstruct()
     {
         $pdoException = new \PDOException("SQLSTATE[HY000] [1049] Unknown database '<dbname>'", 1049);
-        $this->assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
+        static::assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 
     public function testCorrectlyEvaluatesPdoExceptionOnUseDatabase()
@@ -37,7 +38,7 @@ class UnknownDatabaseExceptionTest extends \PHPUnit_Framework_TestCase
         $code = '42000';
         $message = "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '<dbname>'";
         $pdoException = new \PDOException($message, $code);
-        $this->assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
+        static::assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 
     public function testCorrectlyEvaluatesPdoExceptionForNonDatabaseError()
@@ -47,6 +48,6 @@ class UnknownDatabaseExceptionTest extends \PHPUnit_Framework_TestCase
             "check the manual that corresponds to your MySQL server version for the right syntax to use near " .
             "'FRM foo' at line 1";
         $pdoException = new \PDOException($message, $code);
-        $this->assertFalse(UnknownDatabaseException::isUnknownDatabase($pdoException));
+        static::assertFalse(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 }

--- a/tests/Exception/UnknownDatabaseExceptionTest.php
+++ b/tests/Exception/UnknownDatabaseExceptionTest.php
@@ -29,7 +29,7 @@ class UnknownDatabaseExceptionTest extends TestCase
 
     public function testCorrectlyEvaluatesPdoExceptionOnPdoConstruct()
     {
-        $pdoException = new \PDOException("SQLSTATE[HY000] [1049] Unknown database '<dbname>'", 1049);
+        $pdoException = new PDOExceptionStub("SQLSTATE[HY000] [1049] Unknown database '<dbname>'", 1049);
         static::assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 
@@ -37,7 +37,7 @@ class UnknownDatabaseExceptionTest extends TestCase
     {
         $code = '42000';
         $message = "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '<dbname>'";
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         static::assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 
@@ -47,7 +47,7 @@ class UnknownDatabaseExceptionTest extends TestCase
         $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
             'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'FRM foo' at line 1";
-        $pdoException = new \PDOException($message, $code);
+        $pdoException = new PDOExceptionStub($message, $code);
         static::assertFalse(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 }

--- a/tests/Exception/UnknownDatabaseExceptionTest.php
+++ b/tests/Exception/UnknownDatabaseExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests\Exception;
 
 use Phlib\Db\Exception\UnknownDatabaseException;
@@ -7,33 +9,33 @@ use PHPUnit\Framework\TestCase;
 
 class UnknownDatabaseExceptionTest extends TestCase
 {
-    public function testCreateReturnsException()
+    public function testCreateReturnsException(): void
     {
         $exception = UnknownDatabaseException::createFromUnknownDatabase('foo', new \PDOException());
         static::assertInstanceOf(UnknownDatabaseException::class, $exception);
     }
 
-    public function testGetDatabaseName()
+    public function testGetDatabaseName(): void
     {
         $name = 'foo';
         $exception = new UnknownDatabaseException($name, 'message');
         static::assertEquals($name, $exception->getDatabaseName());
     }
 
-    public function testGetDatabaseNameWhenCreated()
+    public function testGetDatabaseNameWhenCreated(): void
     {
         $name = 'foo';
         $exception = UnknownDatabaseException::createFromUnknownDatabase($name, new \PDOException());
         static::assertEquals($name, $exception->getDatabaseName());
     }
 
-    public function testCorrectlyEvaluatesPdoExceptionOnPdoConstruct()
+    public function testCorrectlyEvaluatesPdoExceptionOnPdoConstruct(): void
     {
         $pdoException = new PDOExceptionStub("SQLSTATE[HY000] [1049] Unknown database '<dbname>'", 1049);
         static::assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 
-    public function testCorrectlyEvaluatesPdoExceptionOnUseDatabase()
+    public function testCorrectlyEvaluatesPdoExceptionOnUseDatabase(): void
     {
         $code = '42000';
         $message = "SQLSTATE[42000]: Syntax error or access violation: 1049 Unknown database '<dbname>'";
@@ -41,7 +43,7 @@ class UnknownDatabaseExceptionTest extends TestCase
         static::assertTrue(UnknownDatabaseException::isUnknownDatabase($pdoException));
     }
 
-    public function testCorrectlyEvaluatesPdoExceptionForNonDatabaseError()
+    public function testCorrectlyEvaluatesPdoExceptionForNonDatabaseError(): void
     {
         $code = '42000';
         $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .

--- a/tests/Exception/UnknownDatabaseExceptionTest.php
+++ b/tests/Exception/UnknownDatabaseExceptionTest.php
@@ -44,8 +44,8 @@ class UnknownDatabaseExceptionTest extends TestCase
     public function testCorrectlyEvaluatesPdoExceptionForNonDatabaseError()
     {
         $code = '42000';
-        $message = "SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; " .
-            "check the manual that corresponds to your MySQL server version for the right syntax to use near " .
+        $message = 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; ' .
+            'check the manual that corresponds to your MySQL server version for the right syntax to use near ' .
             "'FRM foo' at line 1";
         $pdoException = new \PDOException($message, $code);
         static::assertFalse(UnknownDatabaseException::isUnknownDatabase($pdoException));

--- a/tests/Exception/UnknownDatabaseExceptionTest.php
+++ b/tests/Exception/UnknownDatabaseExceptionTest.php
@@ -19,14 +19,14 @@ class UnknownDatabaseExceptionTest extends TestCase
     {
         $name = 'foo';
         $exception = new UnknownDatabaseException($name, 'message');
-        static::assertEquals($name, $exception->getDatabaseName());
+        static::assertSame($name, $exception->getDatabaseName());
     }
 
     public function testGetDatabaseNameWhenCreated(): void
     {
         $name = 'foo';
         $exception = UnknownDatabaseException::createFromUnknownDatabase($name, new \PDOException());
-        static::assertEquals($name, $exception->getDatabaseName());
+        static::assertSame($name, $exception->getDatabaseName());
     }
 
     public function testCorrectlyEvaluatesPdoExceptionOnPdoConstruct(): void

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -83,6 +83,16 @@ class IntegrationTest extends TestCase
         $adapter->getConnection();
     }
 
+    public function testRuntimeExceptionStringCode()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Base table or view not found');
+        $this->expectExceptionCode('42S02');
+
+        $this->adapter->setDatabase(getenv('INTEGRATION_DATABASE'));
+        $this->adapter->query('SELECT foo FROM bar');
+    }
+
     public function testInvalidQueryException()
     {
         $this->expectException(InvalidQueryException::class);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests;
 
 use Phlib\Db\Adapter;
@@ -13,22 +15,13 @@ use PHPUnit\Framework\TestCase;
  */
 class IntegrationTest extends TestCase
 {
-    /**
-     * @var Adapter
-     */
-    private $adapter;
+    private Adapter $adapter;
 
-    /**
-     * @var string
-     */
-    private $schemaTable;
+    private string $schemaTable;
 
-    /**
-     * @var string
-     */
-    private $schemaTableQuoted;
+    private string $schemaTableQuoted;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if ((bool)getenv('INTEGRATION_ENABLED') !== true) {
             static::markTestSkipped();
@@ -45,19 +38,19 @@ class IntegrationTest extends TestCase
         ]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (isset($this->schemaTableQuoted)) {
             $this->adapter->query("DROP TABLE {$this->schemaTableQuoted}");
         }
     }
 
-    public function testPing()
+    public function testPing(): void
     {
         static::assertTrue($this->adapter->ping());
     }
 
-    public function testQuery()
+    public function testQuery(): void
     {
         $expected = rand();
 
@@ -67,7 +60,7 @@ class IntegrationTest extends TestCase
         static::assertSame((string)$expected, $result);
     }
 
-    public function testRuntimeException()
+    public function testRuntimeException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Access denied');
@@ -83,7 +76,7 @@ class IntegrationTest extends TestCase
         $adapter->getConnection();
     }
 
-    public function testRuntimeExceptionStringCode()
+    public function testRuntimeExceptionStringCode(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Base table or view not found');
@@ -93,7 +86,7 @@ class IntegrationTest extends TestCase
         $this->adapter->query('SELECT foo FROM bar');
     }
 
-    public function testInvalidQueryException()
+    public function testInvalidQueryException(): void
     {
         $this->expectException(InvalidQueryException::class);
         $this->expectExceptionMessage('error in your SQL syntax');
@@ -102,7 +95,7 @@ class IntegrationTest extends TestCase
         $this->adapter->query('SELECT foo FROM bar WHERE');
     }
 
-    public function testSetDatabaseNotConnectedSuccess()
+    public function testSetDatabaseNotConnectedSuccess(): void
     {
         // Connection not active, will just update config
         $this->adapter->setDatabase(getenv('INTEGRATION_DATABASE'));
@@ -111,7 +104,7 @@ class IntegrationTest extends TestCase
         static::assertTrue($this->adapter->ping());
     }
 
-    public function testSetDatabaseAlreadyConnectedSuccess()
+    public function testSetDatabaseAlreadyConnectedSuccess(): void
     {
         // Make sure connected
         static::assertTrue($this->adapter->ping());
@@ -126,7 +119,7 @@ class IntegrationTest extends TestCase
     /**
      * This test needs the user to have global privileges, otherwise the error will be 'access denied'
      */
-    public function testSetDatabaseNotConnectedFail()
+    public function testSetDatabaseNotConnectedFail(): void
     {
         // Connection not active, will just update config, no exception
         $this->adapter->setDatabase('database_does_not_exist');
@@ -140,7 +133,7 @@ class IntegrationTest extends TestCase
     /**
      * This test needs the user to have global privileges, otherwise the error will be 'access denied'
      */
-    public function testSetDatabaseAlreadyConnectedFail()
+    public function testSetDatabaseAlreadyConnectedFail(): void
     {
         // Make sure connected
         static::assertTrue($this->adapter->ping());
@@ -150,7 +143,7 @@ class IntegrationTest extends TestCase
         $this->adapter->setDatabase('database_does_not_exist');
     }
 
-    public function testBasicDataManip()
+    public function testBasicDataManip(): void
     {
         $this->createTestTable();
         $id = rand();
@@ -183,7 +176,7 @@ SQL;
         static::assertSame(1, $deleteCount);
     }
 
-    public function testCrudMethods()
+    public function testCrudMethods(): void
     {
         $this->createTestTable();
         $id = rand();
@@ -223,7 +216,7 @@ SQL;
         static::assertSame(1, $deleteCount);
     }
 
-    public function testLastInsertId()
+    public function testLastInsertId(): void
     {
         $this->createTestTable();
         $text1 = sha1(uniqid());
@@ -252,7 +245,7 @@ SQL;
         static::assertSame('2', $this->adapter->lastInsertId());
     }
 
-    private function createTestTable()
+    private function createTestTable(): void
     {
         $tableName = 'phlib_db_test_' . substr(sha1(uniqid()), 0, 10);
         $this->schemaTable = getenv('INTEGRATION_DATABASE') . '.' . $tableName;

--- a/tests/SqlFragmentTest.php
+++ b/tests/SqlFragmentTest.php
@@ -13,6 +13,6 @@ class SqlFragmentTest extends TestCase
     {
         $value = 'abc123';
         $sqlFragment = new SqlFragment($value);
-        self::assertEquals($value, (string)$sqlFragment);
+        self::assertSame($value, (string)$sqlFragment);
     }
 }

--- a/tests/SqlFragmentTest.php
+++ b/tests/SqlFragmentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Phlib\Db\Tests;
 
 use Phlib\Db\SqlFragment;
@@ -7,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class SqlFragmentTest extends TestCase
 {
-    public function testToString()
+    public function testToString(): void
     {
         $value = 'abc123';
         $sqlFragment = new SqlFragment($value);


### PR DESCRIPTION
 - Drop PHP <= v7.3.
 - Add PHP v8.
 - Add strict types.
 - Remove `type` param from quoter.
 - Remove support for `null` alias from `columnAs` and `tableAs` quote methods.