### PR TITLE
Stringable type for quoter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add PHP v8 type declarations.
+### Changed
+- An object passed to a quote method now specifically checks for an
+  implementation of `\Stringable`.
+  This is equivalent to the previous behaviour of checking for `__toString()`.
+  Arbitrary objects will be blocked by type declarations.
 ### Removed
 - **BC break**: Removed support for PHP versions <= v8.0 as they are no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -41,7 +41,7 @@ class Adapter implements AdapterInterface
     public function quote(): Adapter\QuoteHandler
     {
         if (!isset($this->quoter)) {
-            $this->quoter = new Adapter\QuoteHandler(function ($value): string {
+            $this->quoter = new Adapter\QuoteHandler(function (string $value): string {
                 return $this->getConnection()->quote($value);
             });
         }

--- a/src/Adapter/QuoteHandler.php
+++ b/src/Adapter/QuoteHandler.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Phlib\Db\Adapter;
 
 use Phlib\Db\Exception\InvalidArgumentException;
+use Phlib\Db\SqlStatement;
 
 class QuoteHandler
 {
     /**
      * @param \Closure{
-     *   value: mixed,
+     *   value: string,
      * }:string $quoteFn
      */
     public function __construct(
@@ -22,13 +23,11 @@ class QuoteHandler
     /**
      * Quote a value for the database
      */
-    public function value(mixed $value): string
-    {
+    public function value(
+        string|\Stringable|array|bool|int|float|null $value,
+    ): string {
         switch (true) {
-            case is_object($value):
-                if (!method_exists($value, '__toString')) {
-                    throw new InvalidArgumentException('Object can not be converted to string value.');
-                }
+            case $value instanceof \Stringable:
                 return (string)$value;
             case is_bool($value):
                 return (string)(int)$value;
@@ -44,16 +43,21 @@ class QuoteHandler
                     return $this->value($value);
                 }, $value);
                 return implode(', ', $value);
-            default:
+            case is_string($value):
                 return ($this->quoteFn)($value);
+            default:
+                // Not reachable due to type declarations
+                throw new InvalidArgumentException('Value can not be converted to string for quoting');
         }
     }
 
     /**
      * Quote a value to replace the `?` placeholder
      */
-    public function into(string $text, mixed $value): string
-    {
+    public function into(
+        string $text,
+        string|\Stringable|array|bool|int|float|null $value,
+    ): string {
         return str_replace('?', $this->value($value), $text);
     }
 
@@ -61,7 +65,7 @@ class QuoteHandler
      * Quote a column identifier and alias
      */
     public function columnAs(
-        string|array|object $ident,
+        string|\Stringable|array $ident,
         string $alias,
         bool $auto = false,
     ): string {
@@ -72,7 +76,7 @@ class QuoteHandler
      * Quote a table identifier and alias
      */
     public function tableAs(
-        string|array|object $ident,
+        string|\Stringable|array $ident,
         string $alias,
         bool $auto = false,
     ): string {
@@ -83,45 +87,42 @@ class QuoteHandler
      * Quote an identifier
      */
     public function identifier(
-        string|array|object $ident,
+        string|\Stringable|array $ident,
         bool $auto = false,
     ): string {
         return $this->quoteIdentifierAs($ident, null, $auto);
     }
 
     private function quoteIdentifierAs(
-        string|array|object $ident,
+        string|\Stringable|array $ident,
         ?string $alias = null,
         bool $auto = false,
         string $as = ' AS ',
     ): string {
-        if (is_object($ident) && method_exists($ident, 'assemble')) {
-            $quoted = '(' . $ident->assemble() . ')';
-        } elseif (is_object($ident)) {
-            if (!method_exists($ident, '__toString')) {
-                throw new InvalidArgumentException('Object can not be converted to string identifier.');
-            }
+        if ($ident instanceof \Stringable) {
             $quoted = (string)$ident;
+            if ($ident instanceof SqlStatement) {
+                $quoted = '(' . $quoted . ')';
+            }
         } else {
             if (is_string($ident)) {
                 $ident = explode('.', $ident);
             }
-            if (is_array($ident)) {
-                $segments = [];
-                foreach ($ident as $segment) {
-                    if (is_object($segment)) {
-                        $segments[] = (string)$segment;
-                    } else {
-                        $segments[] = $this->performQuoteIdentifier($segment, $auto);
-                    }
+
+            $segments = [];
+            foreach ($ident as $segment) {
+                if ($segment instanceof \Stringable) {
+                    $segments[] = (string)$segment;
+                } elseif (is_string($segment)) {
+                    $segments[] = $this->performQuoteIdentifier($segment, $auto);
+                } else {
+                    throw new InvalidArgumentException('Ident array values must be stringable');
                 }
-                if ($alias !== null && end($ident) === $alias) {
-                    $alias = null;
-                }
-                $quoted = implode('.', $segments);
-            } else {
-                $quoted = $this->performQuoteIdentifier($ident, $auto);
             }
+            if ($alias !== null && end($ident) === $alias) {
+                $alias = null;
+            }
+            $quoted = implode('.', $segments);
         }
 
         if ($alias !== null) {
@@ -131,8 +132,10 @@ class QuoteHandler
         return $quoted;
     }
 
-    private function performQuoteIdentifier(string $value, bool $auto = false): string
-    {
+    private function performQuoteIdentifier(
+        string $value,
+        bool $auto = false,
+    ): string {
         if ($auto === false || $this->autoQuoteIdentifiers === true) {
             $q = '`';
             return $q . str_replace("{$q}", "{$q}{$q}", $value) . $q;

--- a/src/SqlFragment.php
+++ b/src/SqlFragment.php
@@ -8,7 +8,7 @@ namespace Phlib\Db;
  * This class will hold a SQL fragment and return it when cast to a string by Db::quote()
  * to avoid the string otherwise being quoted as a value
  */
-class SqlFragment
+class SqlFragment implements \Stringable
 {
     public function __construct(
         private readonly string $value,

--- a/src/SqlStatement.php
+++ b/src/SqlStatement.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phlib\Db;
+
+/**
+ * Interface for SQL statements, e.g. those that may be built dynamically, and rendered as a string.
+ * @private Not part of the BC promise. Placeholder for future implementation.
+ */
+interface SqlStatement extends \Stringable
+{
+}


### PR DESCRIPTION
- Add type checks for `\Stringable` to quoter.
- The PDO default quote method value param has a string type.
- Add a placeholder for dynamic SQL statements to preserve the parentheses quote behaviour.
- Simplify the quote type logic for the expected types.

Must be a major version as it changes the type declarations on the quoter (although there should be no impact on any standard expected usage of the package).