### PR TITLE
Native prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add PHP v8 type declarations.
 ### Changed
+- Set default PDO config `PDO::ATTR_EMULATE_PREPARES = 0`
+  to disable emulated prepares, i.e. use MySQL native prepares.
 - An object passed to a quote method now specifically checks for an
   implementation of `\Stringable`.
   This is equivalent to the previous behaviour of checking for `__toString()`.

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -199,22 +199,37 @@ class Adapter implements AdapterInterface
         return $this->doQuery($sql, $bind);
     }
 
-    private function doQuery(string $sql, ?array $bind, bool $hasCaughtException = false): \PDOStatement
+    private function doQuery(string $sql, ?array $bind): \PDOStatement
     {
         try {
-            $stmt = $this->getConnection()->prepare($sql);
-            if ($bind !== null) {
-                $stmt->execute($bind);
-            }
-            return $stmt;
+            return $this->tryOrReconnect(function () use ($sql, $bind) {
+                $stmt = $this->getConnection()->prepare($sql);
+                if ($bind !== null) {
+                    $stmt->execute($bind);
+                }
+                return $stmt;
+            });
         } catch (\PDOException $exception) {
             if (InvalidQueryException::isInvalidSyntax($exception)) {
                 throw new InvalidQueryException($sql, $bind, $exception);
-            } elseif (RuntimeException::hasServerGoneAway($exception) && !$hasCaughtException) {
-                $this->reconnect();
-                return $this->doQuery($sql, $bind, true);
             }
             throw RuntimeException::createFromException($exception);
+        }
+    }
+
+    /**
+     * @return mixed Value from $closure
+     */
+    private function tryOrReconnect(\Closure $closure): mixed
+    {
+        try {
+            return $closure();
+        } catch (\PDOException $exception) {
+            if (RuntimeException::hasServerGoneAway($exception)) {
+                $this->reconnect();
+                return $closure();
+            }
+            throw $exception;
         }
     }
 
@@ -234,19 +249,12 @@ class Adapter implements AdapterInterface
 
     public function beginTransaction(): bool
     {
-        return $this->doBeginTransaction();
-    }
-
-    private function doBeginTransaction(bool $hasCaughtException = false): bool
-    {
         try {
-            return $this->getConnection()->beginTransaction();
-        } catch (\PDOException $exception) {
-            if (RuntimeException::hasServerGoneAway($exception) && !$hasCaughtException) {
-                $this->reconnect();
-                return $this->doBeginTransaction(true);
-            }
-            throw RuntimeException::createFromException($exception);
+            return $this->tryOrReconnect(
+                fn() => $this->getConnection()->beginTransaction(),
+            );
+        } catch (\PDOException $e) {
+            throw RuntimeException::createFromException($e);
         }
     }
 

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -183,15 +183,14 @@ class Adapter implements AdapterInterface
         return $this->getConnection()->lastInsertId($tablename);
     }
 
-    public function prepare(string $statement): \PDOStatement
+    public function prepare(string $sql): \PDOStatement
     {
-        // the prepare method is emulated by PDO, so no point in detected disconnection
-        return $this->getConnection()->prepare($statement);
+        return $this->doQuery($sql, null);
     }
 
-    public function execute(string $statement, array $bind = []): int
+    public function execute(string $sql, array $bind = []): int
     {
-        $stmt = $this->query($statement, $bind);
+        $stmt = $this->query($sql, $bind);
         return $stmt->rowCount();
     }
 
@@ -200,11 +199,13 @@ class Adapter implements AdapterInterface
         return $this->doQuery($sql, $bind);
     }
 
-    private function doQuery(string $sql, array $bind, bool $hasCaughtException = false): \PDOStatement
+    private function doQuery(string $sql, ?array $bind, bool $hasCaughtException = false): \PDOStatement
     {
         try {
             $stmt = $this->getConnection()->prepare($sql);
-            $stmt->execute($bind);
+            if ($bind !== null) {
+                $stmt->execute($bind);
+            }
             return $stmt;
         } catch (\PDOException $exception) {
             if (InvalidQueryException::isInvalidSyntax($exception)) {

--- a/src/Adapter/Config.php
+++ b/src/Adapter/Config.php
@@ -60,6 +60,7 @@ class Config
             \PDO::ATTR_TIMEOUT => $timeout,
             \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            \PDO::ATTR_EMULATE_PREPARES => 0,
         ];
     }
 

--- a/src/AdapterInterface.php
+++ b/src/AdapterInterface.php
@@ -42,9 +42,9 @@ interface AdapterInterface
      */
     public function lastInsertId(?string $tablename = null): string;
 
-    public function prepare(string $statement): \PDOStatement;
+    public function prepare(string $sql): \PDOStatement;
 
-    public function execute(string $statement, array $bind = []): int;
+    public function execute(string $sql, array $bind = []): int;
 
     public function query(string $sql, array $bind = []): \PDOStatement;
 

--- a/src/Exception/InvalidQueryException.php
+++ b/src/Exception/InvalidQueryException.php
@@ -13,7 +13,7 @@ class InvalidQueryException extends RuntimeException implements Exception
 
     public function __construct(
         private readonly string $query,
-        private readonly array $bind = [],
+        private readonly ?array $bind = null,
         ?\PDOException $previous = null,
     ) {
         $message = 'You have an error in your SQL syntax.';
@@ -22,7 +22,11 @@ class InvalidQueryException extends RuntimeException implements Exception
             $message = $previous->getMessage();
             $code = (int)$previous->getCode();
         }
-        $message .= ' SQL: ' . $this->query . ' Bind: ' . var_export($this->bind, true);
+        $message .= '; SQL: ' . $this->query;
+
+        if ($this->bind !== null) {
+            $message .= '; Bind: ' . var_export($this->bind, true);
+        }
 
         parent::__construct($message, $code, $previous);
     }
@@ -32,7 +36,7 @@ class InvalidQueryException extends RuntimeException implements Exception
         return $this->query;
     }
 
-    public function getBindData(): array
+    public function getBindData(): ?array
     {
         return $this->bind;
     }

--- a/tests/Adapter/ConfigTest.php
+++ b/tests/Adapter/ConfigTest.php
@@ -134,6 +134,20 @@ class ConfigTest extends TestCase
                 \PDO::ATTR_DEFAULT_FETCH_MODE,
                 \PDO::FETCH_COLUMN,
             ],
+            'emulate-default' => [
+                [],
+                \PDO::ATTR_EMULATE_PREPARES,
+                0,
+            ],
+            'emulate-override' => [
+                [
+                    'attributes' => [
+                        \PDO::ATTR_EMULATE_PREPARES => 1,
+                    ],
+                ],
+                \PDO::ATTR_EMULATE_PREPARES,
+                1,
+            ],
             'attributes-one' => [
                 [
                     'attributes' => [


### PR DESCRIPTION
- Use MySQL native prepares by default.
- Separate and reuse the reconnect behaviour.